### PR TITLE
[3.0.0] Added much stricter typing #4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -15,24 +15,9 @@ declare type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
 declare type EventOrReactEvent = Event | React.SyntheticEvent | InputChangeEvent;
 declare type EventOrValue = InputChangeEvent | string;
 declare type Key = string | number | symbol;
-/** This complex type allows us to typecheck arrays of paths up to 5 deep */
-declare type TypeSafeKeys<T, T1 extends keyof T = keyof T> = T1 | TypeSafeKeysArray<T>;
-declare type TypeSafeKeysArray<T, T1 extends keyof T = keyof T, T2 extends keyof T[T1] = keyof T[T1], T3 extends keyof T[T1][T2] = keyof T[T1][T2], T4 extends keyof T[T1][T2][T3] = keyof T[T1][T2][T3], T5 extends keyof T[T1][T2][T3][T4] = keyof T[T1][T2][T3][T4]> = TypeSafeKeysArray1<T, T1> | TypeSafeKeysArray2<T, T1, T2> | TypeSafeKeysArray3<T, T1, T2, T3> | TypeSafeKeysArray4<T, T1, T2, T3, T4> | TypeSafeKeysArray5Plus<T, T1, T2, T3, T4, T5>;
-declare type TypeSafeKeysArray1<T, T1 extends keyof T> = [T1];
-declare type TypeSafeKeysArray2<T, T1 extends keyof T, T2 extends keyof T[T1]> = [T1, T2];
-declare type TypeSafeKeysArray3<T, T1 extends keyof T, T2 extends keyof T[T1], T3 extends keyof T[T1][T2]> = [T1, T2, T3];
-declare type TypeSafeKeysArray4<T, T1 extends keyof T, T2 extends keyof T[T1], T3 extends keyof T[T1][T2], T4 extends keyof T[T1][T2][T3]> = [T1, T2, T3, T4];
-declare type TypeSafeKeysArray5Plus<T, T1 extends keyof T, T2 extends keyof T[T1], T3 extends keyof T[T1][T2], T4 extends keyof T[T1][T2][T3], T5 extends keyof T[T1][T2][T3][T4]> = [T1, T2, T3, T4, T5, ...Key[]];
-/**
- * Like TypeSafeKeys, but for `indexInProp` which excludes the prop itself.
- * Typechecks keys (including array keys) up to 5 levels deep.
- */
-declare type TypeSafeIndexInProp<T, PropK extends keyof T = keyof T, T1 extends keyof T[PropK] = keyof T[PropK], T2 extends keyof T[PropK][T1] = keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2] = keyof T[PropK][T1][T2], T4 extends keyof T[PropK][T1][T2][T3] = keyof T[PropK][T1][T2][T3], T5 extends keyof T[PropK][T1][T2][T3][T4] = keyof T[PropK][T1][T2][T3][T4]> = T1 | TypeSafeIndexInPropArray1<T, PropK, T1> | TypeSafeIndexInPropArray2<T, PropK, T1, T2> | TypeSafeIndexInPropArray3<T, PropK, T1, T2, T3> | TypeSafeIndexInPropArray4<T, PropK, T1, T2, T3, T4> | TypeSafeIndexInPropArray5Plus<T, PropK, T1, T2, T3, T4, T5>;
-declare type TypeSafeIndexInPropArray1<T, PropK extends keyof T, T1 extends keyof T[PropK]> = [T1];
-declare type TypeSafeIndexInPropArray2<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1]> = [T1, T2];
-declare type TypeSafeIndexInPropArray3<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2]> = [T1, T2, T3];
-declare type TypeSafeIndexInPropArray4<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2], T4 extends keyof T[PropK][T1][T2][T3]> = [T1, T2, T3, T4];
-declare type TypeSafeIndexInPropArray5Plus<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2], T4 extends keyof T[PropK][T1][T2][T3], T5 extends keyof T[PropK][T1][T2][T3][T4]> = [T1, T2, T3, T4, T5, ...Key[]];
+/** Type-checks a string key or the first key in an array of keys */
+declare type TypeSafeKeys<T> = keyof T | TypeSafeKeysArray<T>;
+declare type TypeSafeKeysArray<T> = [keyof T, ...Key[]];
 declare type GetNewValueFunc = (curValue: unknown, event: EventOrValue) => unknown;
 /**
  * Set a variable deep in a map/array while preserving immutable semantics
@@ -80,7 +65,7 @@ export declare function toggle<PropT, StateT>(elem: React.Component<PropT, State
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: TypeSafeIndexInProp<PropT> | null, preventDefault?: boolean): (e?: any) => any;
+export declare function toggleProp<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp?: TypeSafeKeys<PropT[PropK]> | null, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key to either the value given or null
@@ -101,7 +86,7 @@ export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, 
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropValue<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key given by path to either the value passed (if it's
@@ -123,7 +108,7 @@ export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<Pro
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT>, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropFromEvent<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]>, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it);
@@ -154,7 +139,7 @@ export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<P
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropArrayMember<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle whether a value (passed in
  * as an argument) should be in an array at the given prop key
@@ -167,7 +152,7 @@ export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT
  *                        if propIndex already points to the array)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropArrayMemberFromEvent<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information given
@@ -179,7 +164,7 @@ export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Compon
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, preventDefault?: boolean): (e?: any) => any;
+export declare function setProp<PropT, PropK extends keyof PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information from an event
@@ -192,7 +177,7 @@ export declare function setProp<PropT>(elem: React.Component<any>, propFunc: key
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, preventDefault?: boolean): (e?: any) => any;
+export declare function setPropNumber<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * to a set value
@@ -205,7 +190,7 @@ export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propF
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function setPropValue<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will delete a certain key from a prop
  * and then call an onChange handler; works for both arrays and
@@ -218,7 +203,7 @@ export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFu
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT>, preventDefault?: boolean): (e?: any) => any;
+export declare function deleteProp<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]>, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed
@@ -363,7 +348,7 @@ export declare function setOrNull(curValue: any, e: EventOrValue): string | null
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e?: any) => any;
+export declare function changeProp<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a state
  * based on the "getNewValue" function supplied

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,14 +1,16 @@
 import React from 'react';
 export declare function preventDefault(event: Event): void;
 export declare function stopPropagation(event: Event): void;
-export declare function preventDefaultAndBlur(event: Event): void;
+export declare function preventDefaultAndBlur(event: Event | InputChangeEvent): void;
 /**
  * Many onChange functions either get passed an event (with the changed value
  * in e.target.value) or just the changed value; this disambiguates the two
  */
-declare type EventOrValue = React.ChangeEvent<HTMLInputElement> | any;
-declare type Key = string | number;
+declare type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
+declare type EventOrValue = InputChangeEvent | string;
+declare type Key = string | number | symbol;
 declare type Keys = Key | Key[];
+declare type TypeSafeKeys<T> = keyof T | [keyof T, ...(string | number)[]];
 declare type GetNewValueFunc = (curValue: unknown, event: EventOrValue) => unknown;
 /**
  * Set a variable deep in a map/array while preserving immutable semantics
@@ -18,7 +20,7 @@ declare type GetNewValueFunc = (curValue: unknown, event: EventOrValue) => unkno
  * @param withType    if specified, used with _setWith; currently disabled
  * @return modified root obj
  */
-export declare function set(obj: Object | any[], keys: Keys, value: any, withType?: any | null): Object | any[];
+export declare function set<T extends Object>(obj: T, keys: Keys, value: any, withType?: any | null): T;
 /**
  * Get a variable deep in a map that's potentially partly
  * immutable and partly not
@@ -34,7 +36,7 @@ export declare function get(obj: Object | any[], keys: Keys): any;
  * @param keys  path of item to delete
  * @return updated obj (with shallow copies to preserve immutable semantics)
  */
-export declare function deleteDeep(obj: Object | any[], keys: Keys): Object | any[];
+export declare function deleteDeep<T extends Object>(obj: T, keys: Keys): T;
 export declare const setMixed: typeof set;
 export declare const getMixed: typeof get;
 export declare const deleteMixed: typeof deleteDeep;
@@ -45,7 +47,7 @@ export declare const deleteMixed: typeof deleteDeep;
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggle(elem: React.Component<any>, stateIndex: Keys, preventDefault?: boolean): any;
+export declare function toggle<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -56,7 +58,7 @@ export declare function toggle(elem: React.Component<any>, stateIndex: Keys, pre
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleProp(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp?: Keys | null, preventDefault?: boolean): any;
+export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp?: Keys | null, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key to either the value given or null
@@ -65,7 +67,7 @@ export declare function toggleProp(elem: React.Component<any>, propFunc: string,
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleValue(elem: React.Component<any>, stateIndex: Keys, value: any, preventDefault?: boolean): any;
+export declare function toggleValue<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -77,7 +79,7 @@ export declare function toggleValue(elem: React.Component<any>, stateIndex: Keys
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropValue(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys | null, value: any, preventDefault?: boolean): any;
+export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key given by path to either the value passed (if it's
@@ -86,7 +88,7 @@ export declare function togglePropValue(elem: React.Component<any>, propFunc: st
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleFromEvent(elem: React.Component<any>, stateIndex: Keys, preventDefault?: boolean): any;
+export declare function toggleFromEvent<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc to:
@@ -99,7 +101,7 @@ export declare function toggleFromEvent(elem: React.Component<any>, stateIndex: 
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropFromEvent(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys, value: any, preventDefault?: boolean): any;
+export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it);
@@ -108,7 +110,7 @@ export declare function togglePropFromEvent(elem: React.Component<any>, propFunc
  * @param stateIndex      path (array or string) of array in state to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMemberFromEvent(elem: React.Component<any>, stateIndex: Keys, preventDefault?: boolean): any;
+export declare function toggleArrayMemberFromEvent<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it)
@@ -117,7 +119,7 @@ export declare function toggleArrayMemberFromEvent(elem: React.Component<any>, s
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMember(elem: React.Component<any>, stateIndex: Keys, value: any, preventDefault?: boolean): any;
+export declare function toggleArrayMember<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given prop key (by adding or removing it)
@@ -130,7 +132,7 @@ export declare function toggleArrayMember(elem: React.Component<any>, stateIndex
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMember(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
+export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value (passed in
  * as an argument) should be in an array at the given prop key
@@ -143,7 +145,7 @@ export declare function togglePropArrayMember(elem: React.Component<any>, propFu
  *                        if propIndex already points to the array)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMemberFromEvent(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information given
@@ -155,7 +157,7 @@ export declare function togglePropArrayMemberFromEvent(elem: React.Component<any
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setProp(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function setProp<PropT>(elem: React.Component<any>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information from an event
@@ -168,7 +170,7 @@ export declare function setProp(elem: React.Component<any>, propFunc: string, pr
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropNumber(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
 /**
  * Get an event handler that will set the value of a prop
  * to a set value
@@ -181,7 +183,7 @@ export declare function setPropNumber(elem: React.Component<any>, propFunc: stri
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropValue(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
+export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will delete a certain key from a prop
  * and then call an onChange handler; works for both arrays and
@@ -194,7 +196,7 @@ export declare function setPropValue(elem: React.Component<any>, propFunc: strin
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function deleteProp(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys, preventDefault?: boolean): any;
+export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys, preventDefault?: boolean): any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed
@@ -202,7 +204,7 @@ export declare function deleteProp(elem: React.Component<any>, propFunc: string,
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function update(elem: React.Component<any>, stateIndex: Keys, preventDefault?: boolean): any;
+export declare function update<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed to a numeric (or null) value
@@ -210,7 +212,7 @@ export declare function update(elem: React.Component<any>, stateIndex: Keys, pre
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function updateNumber(elem: React.Component<any>, stateIndex: Keys, preventDefault?: boolean): any;
+export declare function updateNumber<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get a function that will set the state for a certain element
  * @param elem            React element; usually "this"
@@ -218,7 +220,7 @@ export declare function updateNumber(elem: React.Component<any>, stateIndex: Key
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function setState(elem: React.Component<any>, stateIndex: Keys, value: any, preventDefault?: boolean): any;
+export declare function setState<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
 /**
  * Get a function that will delete a key from within the state
  * @param elem            React element; usually "this"
@@ -226,7 +228,7 @@ export declare function setState(elem: React.Component<any>, stateIndex: Keys, v
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function deleteState(elem: React.Component<any>, stateIndex: Keys, preventDefault?: boolean): any;
+export declare function deleteState<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Filters a changed state variable so that we only include
  * keys that were changed
@@ -234,11 +236,7 @@ export declare function deleteState(elem: React.Component<any>, stateIndex: Keys
  * @param changedState   new state
  * @return changeState, with only the keys that are different from origState
  */
-export declare function getChanged(origState: {
-    [k: string]: any;
-}, changedState: {
-    [k: string]: any;
-}): {};
+export declare function getChanged<StateT extends Object>(origState: StateT, changedState: StateT): Partial<StateT>;
 interface Response {
     success: boolean;
     data: any;
@@ -251,7 +249,7 @@ interface Response {
  * @param loadingKey   key in elem.state to set the loading
  * @param dataKey      key in elem.state to set the data (from data.data)
  */
-export declare function getThen(elem: React.Component<any>, responseKey?: string, loadingKey?: string, dataKey?: string): any;
+export declare function getThen(elem: React.Component<any>, responseKey?: string, loadingKey?: string, dataKey?: string): (data: Response) => void;
 /**
  * The default message handler for request from the server
  * @param elem  element to get a "then" handler for
@@ -259,7 +257,7 @@ export declare function getThen(elem: React.Component<any>, responseKey?: string
  * @param loadingKey   key in elem.state to set the loading
  * @param dataKey      key in elem.state to set the data (from data.data)
  */
-export declare function getCatch(elem: React.Component<any>, responseKey?: string, loadingKey?: string): any;
+export declare function getCatch(elem: React.Component<any>, responseKey?: string, loadingKey?: string): (err: Error) => void;
 /**
  * Render an alert based on the output from a defaultThen
  * and defaultCatch
@@ -284,12 +282,12 @@ export declare function renderResponse(response: Response, options: {
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export declare function all(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): any;
+export declare function all(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: Event) => void;
 /**
  * getNewValue (updater) function that sets the value to that
  * received in the event
  */
-export declare function fromEvent(curValue: unknown, e: EventOrValue): any;
+export declare function fromEvent(curValue: unknown, e: EventOrValue): string;
 /**
  * getNewValue (updater) function that sets the value to that
  * received in the event, cast to a number
@@ -304,7 +302,7 @@ export declare function constant<T>(value: T): (() => T);
  * Generator of a getNewValue (updater) function that
  * deletes a key from within an object
  */
-export declare function remove(indexToDelete: Keys): (curValue: Object | any[]) => Object | any[];
+export declare function remove(indexToDelete: Keys): <T extends Object>(curValue: T) => T;
 /**
  * Generator of a getNewValue (updater) function that
  * adds or splices an element from an array based on
@@ -325,12 +323,12 @@ export declare function negate(curValue: unknown): boolean;
  * getNewValue (updater) function that sets the value to that of the constant,
  * or if it's already the same, nulls it
  */
-export declare function toggleConstant(value: unknown | null): (curValue: unknown) => unknown;
+export declare function toggleConstant<T>(value: T | null): (curValue: T | null) => T | null;
 /**
  * getNewValue (updater) function that sets the value to that from an event,
  * or if it's already the same, nulls it
  */
-export declare function setOrNull(curValue: any, e: EventOrValue): any;
+export declare function setOrNull(curValue: any, e: EventOrValue): string | null;
 /**
  * Get an event handler that will set the value of a prop
  * based on the "getNewValue" function supplied
@@ -343,7 +341,7 @@ export declare function setOrNull(curValue: any, e: EventOrValue): any;
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeProp(elem: React.Component<any>, propFunc: string, propIndex: Keys, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
  * Get an event handler that will set the value of a state
  * based on the "getNewValue" function supplied
@@ -354,7 +352,7 @@ export declare function changeProp(elem: React.Component<any>, propFunc: string,
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeState(elem: React.Component<any>, stateIndex: Keys, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function changeState<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
  * Get an event handler that will call a function on the React
  * component
@@ -365,7 +363,7 @@ export declare function changeState(elem: React.Component<any>, stateIndex: Keys
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return handler that calls a component function
  */
-export declare function call(elem: React.Component<any>, funcName: Keys, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function call<T extends Object>(elem: T, funcName: TypeSafeKeys<T>, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
  * Get an event handler that will call a function on the React
  * component's props with given arguments
@@ -376,15 +374,18 @@ export declare function call(elem: React.Component<any>, funcName: Keys, prefixA
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return handler that calls a component function
  */
-export declare function callProp(elem: React.Component<any>, funcName: Keys, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function callProp<PropT>(elem: React.Component<PropT>, funcName: TypeSafeKeys<PropT>, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
+ * @deprecated
+ * Prefer using `React.createRef` object-based refs instead of this function.
+ *
  * Get a function to be used with ref={} to register a ref into
- * a variable in the current object
+ * a variable in the current object.
  * @param {Object} elem          React component (usually `this`)
  * @param {String} variableName  Name to save ref (e.g., '_elem' for this._elem)
  * @return {function} handler for ref=}}
  */
-export declare function registerRef(elem: React.Component<any>, variableName: Keys): any;
+export declare function registerRef<T extends Object>(elem: T, variableName: Keys): any;
 declare const _default: {
     preventDefault: typeof preventDefault;
     stopPropagation: typeof stopPropagation;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,16 +1,38 @@
 import React from 'react';
-export declare function preventDefault(event: Event): void;
-export declare function stopPropagation(event: Event): void;
-export declare function preventDefaultAndBlur(event: React.SyntheticEvent | Event): void;
+export declare function preventDefault(event: EventOrReactEvent): void;
+export declare function stopPropagation(event: EventOrReactEvent): void;
+/**
+ * This function can handle any type gracefully, so calling functions don't
+ * have to check if the input is an event. It'll do nothing if the input isn't
+ * an event.
+ */
+export declare function preventDefaultAndBlur(eventOrAny: any): void;
 /**
  * Many onChange functions either get passed an event (with the changed value
  * in e.target.value) or just the changed value; this disambiguates the two
  */
 declare type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
+declare type EventOrReactEvent = Event | React.SyntheticEvent | InputChangeEvent;
 declare type EventOrValue = InputChangeEvent | string;
 declare type Key = string | number | symbol;
-declare type Keys = Key | Key[];
-declare type TypeSafeKeys<T> = keyof T | [keyof T, ...(string | number)[]];
+/** This complex type allows us to typecheck arrays of paths up to 5 deep */
+declare type TypeSafeKeys<T, T1 extends keyof T = keyof T> = T1 | TypeSafeKeysArray<T>;
+declare type TypeSafeKeysArray<T, T1 extends keyof T = keyof T, T2 extends keyof T[T1] = keyof T[T1], T3 extends keyof T[T1][T2] = keyof T[T1][T2], T4 extends keyof T[T1][T2][T3] = keyof T[T1][T2][T3], T5 extends keyof T[T1][T2][T3][T4] = keyof T[T1][T2][T3][T4]> = TypeSafeKeysArray1<T, T1> | TypeSafeKeysArray2<T, T1, T2> | TypeSafeKeysArray3<T, T1, T2, T3> | TypeSafeKeysArray4<T, T1, T2, T3, T4> | TypeSafeKeysArray5Plus<T, T1, T2, T3, T4, T5>;
+declare type TypeSafeKeysArray1<T, T1 extends keyof T> = [T1];
+declare type TypeSafeKeysArray2<T, T1 extends keyof T, T2 extends keyof T[T1]> = [T1, T2];
+declare type TypeSafeKeysArray3<T, T1 extends keyof T, T2 extends keyof T[T1], T3 extends keyof T[T1][T2]> = [T1, T2, T3];
+declare type TypeSafeKeysArray4<T, T1 extends keyof T, T2 extends keyof T[T1], T3 extends keyof T[T1][T2], T4 extends keyof T[T1][T2][T3]> = [T1, T2, T3, T4];
+declare type TypeSafeKeysArray5Plus<T, T1 extends keyof T, T2 extends keyof T[T1], T3 extends keyof T[T1][T2], T4 extends keyof T[T1][T2][T3], T5 extends keyof T[T1][T2][T3][T4]> = [T1, T2, T3, T4, T5, ...Key[]];
+/**
+ * Like TypeSafeKeys, but for `indexInProp` which excludes the prop itself.
+ * Typechecks keys (including array keys) up to 5 levels deep.
+ */
+declare type TypeSafeIndexInProp<T, PropK extends keyof T = keyof T, T1 extends keyof T[PropK] = keyof T[PropK], T2 extends keyof T[PropK][T1] = keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2] = keyof T[PropK][T1][T2], T4 extends keyof T[PropK][T1][T2][T3] = keyof T[PropK][T1][T2][T3], T5 extends keyof T[PropK][T1][T2][T3][T4] = keyof T[PropK][T1][T2][T3][T4]> = T1 | TypeSafeIndexInPropArray1<T, PropK, T1> | TypeSafeIndexInPropArray2<T, PropK, T1, T2> | TypeSafeIndexInPropArray3<T, PropK, T1, T2, T3> | TypeSafeIndexInPropArray4<T, PropK, T1, T2, T3, T4> | TypeSafeIndexInPropArray5Plus<T, PropK, T1, T2, T3, T4, T5>;
+declare type TypeSafeIndexInPropArray1<T, PropK extends keyof T, T1 extends keyof T[PropK]> = [T1];
+declare type TypeSafeIndexInPropArray2<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1]> = [T1, T2];
+declare type TypeSafeIndexInPropArray3<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2]> = [T1, T2, T3];
+declare type TypeSafeIndexInPropArray4<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2], T4 extends keyof T[PropK][T1][T2][T3]> = [T1, T2, T3, T4];
+declare type TypeSafeIndexInPropArray5Plus<T, PropK extends keyof T, T1 extends keyof T[PropK], T2 extends keyof T[PropK][T1], T3 extends keyof T[PropK][T1][T2], T4 extends keyof T[PropK][T1][T2][T3], T5 extends keyof T[PropK][T1][T2][T3][T4]> = [T1, T2, T3, T4, T5, ...Key[]];
 declare type GetNewValueFunc = (curValue: unknown, event: EventOrValue) => unknown;
 /**
  * Set a variable deep in a map/array while preserving immutable semantics
@@ -20,7 +42,7 @@ declare type GetNewValueFunc = (curValue: unknown, event: EventOrValue) => unkno
  * @param withType    if specified, used with _setWith; currently disabled
  * @return modified root obj
  */
-export declare function set<T extends Object>(obj: T, keys: Keys, value: any, withType?: any | null): T;
+export declare function set<T extends Object>(obj: T, keys: TypeSafeKeys<T>, value: any, withType?: any | null): T;
 /**
  * Get a variable deep in a map that's potentially partly
  * immutable and partly not
@@ -28,7 +50,7 @@ export declare function set<T extends Object>(obj: T, keys: Keys, value: any, wi
  * @param keys  path to the property to get
  * @return value or undefined
  */
-export declare function get(obj: Object | any[], keys: Keys): any;
+export declare function get<T extends Object>(obj: T, keys: TypeSafeKeys<T>): any;
 /**
  * Delete a variable deep in a map that's potentially partly
  * immutable and partly not
@@ -36,7 +58,7 @@ export declare function get(obj: Object | any[], keys: Keys): any;
  * @param keys  path of item to delete
  * @return updated obj (with shallow copies to preserve immutable semantics)
  */
-export declare function deleteDeep<T extends Object>(obj: T, keys: Keys): T;
+export declare function deleteDeep<T extends Object>(obj: T, keys: TypeSafeKeys<T>): T;
 export declare const setMixed: typeof set;
 export declare const getMixed: typeof get;
 export declare const deleteMixed: typeof deleteDeep;
@@ -58,7 +80,7 @@ export declare function toggle<PropT, StateT>(elem: React.Component<PropT, State
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: Keys | null, preventDefault?: boolean): (e?: any) => any;
+export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: TypeSafeIndexInProp<PropT> | null, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key to either the value given or null
@@ -79,7 +101,7 @@ export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, 
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key given by path to either the value passed (if it's
@@ -101,7 +123,7 @@ export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<Pro
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT>, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it);
@@ -132,7 +154,7 @@ export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<P
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle whether a value (passed in
  * as an argument) should be in an array at the given prop key
@@ -145,7 +167,7 @@ export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT
  *                        if propIndex already points to the array)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e?: any) => any;
+export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information given
@@ -157,7 +179,7 @@ export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Compon
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e?: any) => any;
+export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information from an event
@@ -170,7 +192,7 @@ export declare function setProp<PropT>(elem: React.Component<any>, propFunc: key
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e?: any) => any;
+export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * to a set value
@@ -183,7 +205,7 @@ export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propF
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
+export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will delete a certain key from a prop
  * and then call an onChange handler; works for both arrays and
@@ -196,7 +218,7 @@ export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFu
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, preventDefault?: boolean): (e?: any) => any;
+export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT>, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed
@@ -302,7 +324,7 @@ export declare function constant<T>(value: T): () => T;
  * Generator of a getNewValue (updater) function that
  * deletes a key from within an object
  */
-export declare function remove(indexToDelete: Keys): <T extends Object>(curValue: T) => T;
+export declare function remove<T extends Object>(indexToDelete: TypeSafeKeys<T>): (curValue: T) => T;
 /**
  * Generator of a getNewValue (updater) function that
  * adds or splices an element from an array based on
@@ -341,7 +363,7 @@ export declare function setOrNull(curValue: any, e: EventOrValue): string | null
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e?: any) => any;
+export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: TypeSafeIndexInProp<PropT> | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a state
  * based on the "getNewValue" function supplied
@@ -385,7 +407,7 @@ export declare function callProp<PropT>(elem: React.Component<PropT>, funcName: 
  * @param {String} variableName  Name to save ref (e.g., '_elem' for this._elem)
  * @return {function} handler for ref=}}
  */
-export declare function registerRef<T extends Object>(elem: T, variableName: Keys): (pageElem: any) => void;
+export declare function registerRef<T extends Object>(elem: T, variableName: keyof T): (pageElem: any) => void;
 declare const _default: {
     preventDefault: typeof preventDefault;
     stopPropagation: typeof stopPropagation;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -47,7 +47,7 @@ export declare const deleteMixed: typeof deleteDeep;
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggle<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
+export declare function toggle<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -58,7 +58,7 @@ export declare function toggle<PropT, StateT>(elem: React.Component<PropT, State
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: Keys | null, preventDefault?: boolean): (e: any) => any;
+export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: Keys | null, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key to either the value given or null
@@ -67,7 +67,7 @@ export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e: any) => StateT;
+export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -79,7 +79,7 @@ export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, 
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null, value: any, preventDefault?: boolean): (e: any) => any;
+export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key given by path to either the value passed (if it's
@@ -88,7 +88,7 @@ export declare function togglePropValue<PropT>(elem: React.Component<PropT>, pro
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
+export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc to:
@@ -101,7 +101,7 @@ export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<Pro
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, value: any, preventDefault?: boolean): (e: any) => any;
+export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it);
@@ -110,7 +110,7 @@ export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>,
  * @param stateIndex      path (array or string) of array in state to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMemberFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
+export declare function toggleArrayMemberFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it)
@@ -119,7 +119,7 @@ export declare function toggleArrayMemberFromEvent<PropT, StateT>(elem: React.Co
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e: any) => StateT;
+export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given prop key (by adding or removing it)
@@ -132,7 +132,7 @@ export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<P
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e: any) => any;
+export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will toggle whether a value (passed in
  * as an argument) should be in an array at the given prop key
@@ -145,7 +145,7 @@ export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT
  *                        if propIndex already points to the array)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e: any) => any;
+export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information given
@@ -157,7 +157,7 @@ export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Compon
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e: any) => any;
+export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information from an event
@@ -170,7 +170,7 @@ export declare function setProp<PropT>(elem: React.Component<any>, propFunc: key
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e: any) => any;
+export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * to a set value
@@ -183,7 +183,7 @@ export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propF
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e: any) => any;
+export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will delete a certain key from a prop
  * and then call an onChange handler; works for both arrays and
@@ -196,7 +196,7 @@ export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFu
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, preventDefault?: boolean): (e: any) => any;
+export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed
@@ -204,7 +204,7 @@ export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function update<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
+export declare function update<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed to a numeric (or null) value
@@ -212,7 +212,7 @@ export declare function update<PropT, StateT>(elem: React.Component<PropT, State
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function updateNumber<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
+export declare function updateNumber<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get a function that will set the state for a certain element
  * @param elem            React element; usually "this"
@@ -220,7 +220,7 @@ export declare function updateNumber<PropT, StateT>(elem: React.Component<PropT,
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function setState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e: any) => StateT;
+export declare function setState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Get a function that will delete a key from within the state
  * @param elem            React element; usually "this"
@@ -228,7 +228,7 @@ export declare function setState<PropT, StateT>(elem: React.Component<PropT, Sta
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function deleteState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
+export declare function deleteState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e?: any) => StateT;
 /**
  * Filters a changed state variable so that we only include
  * keys that were changed
@@ -282,7 +282,7 @@ export declare function renderResponse(response: Response, options: {
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export declare function all(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: any) => void;
+export declare function all(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e?: any) => void;
 /**
  * getNewValue (updater) function that sets the value to that
  * received in the event
@@ -341,7 +341,7 @@ export declare function setOrNull(curValue: any, e: EventOrValue): string | null
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e: any) => any;
+export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a state
  * based on the "getNewValue" function supplied
@@ -352,7 +352,7 @@ export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e: any) => StateT;
+export declare function changeState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e?: any) => StateT;
 /**
  * Get an event handler that will call a function on the React
  * component
@@ -385,7 +385,7 @@ export declare function callProp<PropT>(elem: React.Component<PropT>, funcName: 
  * @param {String} variableName  Name to save ref (e.g., '_elem' for this._elem)
  * @return {function} handler for ref=}}
  */
-export declare function registerRef<T extends Object>(elem: T, variableName: Keys): any;
+export declare function registerRef<T extends Object>(elem: T, variableName: Keys): (pageElem: any) => void;
 declare const _default: {
     preventDefault: typeof preventDefault;
     stopPropagation: typeof stopPropagation;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -164,7 +164,7 @@ export declare function togglePropArrayMemberFromEvent<PropT, PropK extends keyo
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setProp<PropT, PropK extends keyof PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, preventDefault?: boolean): (e?: any) => any;
+export declare function setProp<PropT, PropK extends keyof PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: PropK, indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined, preventDefault?: boolean): (e?: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information from an event

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,13 +1,14 @@
 import React from 'react';
-export declare function preventDefault(event: Event): void;
-export declare function stopPropagation(event: Event): void;
-export declare function preventDefaultAndBlur(event: Event | InputChangeEvent): void;
+export declare function preventDefault(event: AnyEvent): void;
+export declare function stopPropagation(event: AnyEvent): void;
+export declare function preventDefaultAndBlur<EventT extends AnyEvent>(event: EventT): void;
 /**
  * Many onChange functions either get passed an event (with the changed value
  * in e.target.value) or just the changed value; this disambiguates the two
  */
 declare type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
 declare type EventOrValue = InputChangeEvent | string;
+declare type AnyEvent = React.SyntheticEvent | Event;
 declare type Key = string | number | symbol;
 declare type Keys = Key | Key[];
 declare type TypeSafeKeys<T> = keyof T | [keyof T, ...(string | number)[]];
@@ -282,7 +283,7 @@ export declare function renderResponse(response: Response, options: {
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export declare function all(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: Event) => void;
+export declare function all<EventT extends AnyEvent>(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: EventT) => void;
 /**
  * getNewValue (updater) function that sets the value to that
  * received in the event

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -47,7 +47,7 @@ export declare const deleteMixed: typeof deleteDeep;
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggle<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function toggle<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -58,7 +58,7 @@ export declare function toggle<PropT, StateT>(elem: React.Component<PropT, State
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: Keys | null, preventDefault?: boolean): any;
+export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: Keys | null, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key to either the value given or null
@@ -67,7 +67,7 @@ export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
+export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -79,7 +79,7 @@ export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, 
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null, value: any, preventDefault?: boolean): any;
+export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null, value: any, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key given by path to either the value passed (if it's
@@ -88,7 +88,7 @@ export declare function togglePropValue<PropT>(elem: React.Component<PropT>, pro
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc to:
@@ -101,7 +101,7 @@ export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<Pro
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, value: any, preventDefault?: boolean): any;
+export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, value: any, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it);
@@ -110,7 +110,7 @@ export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>,
  * @param stateIndex      path (array or string) of array in state to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMemberFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function toggleArrayMemberFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it)
@@ -119,7 +119,7 @@ export declare function toggleArrayMemberFromEvent<PropT, StateT>(elem: React.Co
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
+export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given prop key (by adding or removing it)
@@ -132,7 +132,7 @@ export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<P
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
+export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will toggle whether a value (passed in
  * as an argument) should be in an array at the given prop key
@@ -145,7 +145,7 @@ export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT
  *                        if propIndex already points to the array)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information given
@@ -157,7 +157,7 @@ export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Compon
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information from an event
@@ -170,7 +170,7 @@ export declare function setProp<PropT>(elem: React.Component<any>, propFunc: key
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will set the value of a prop
  * to a set value
@@ -183,7 +183,7 @@ export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propF
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
+export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): (e: any) => any;
 /**
  * Get an event handler that will delete a certain key from a prop
  * and then call an onChange handler; works for both arrays and
@@ -196,7 +196,7 @@ export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFu
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, preventDefault?: boolean): any;
+export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, preventDefault?: boolean): (e: any) => any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed
@@ -204,7 +204,7 @@ export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function update<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function update<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed to a numeric (or null) value
@@ -212,7 +212,7 @@ export declare function update<PropT, StateT>(elem: React.Component<PropT, State
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function updateNumber<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function updateNumber<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get a function that will set the state for a certain element
  * @param elem            React element; usually "this"
@@ -220,7 +220,7 @@ export declare function updateNumber<PropT, StateT>(elem: React.Component<PropT,
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function setState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
+export declare function setState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Get a function that will delete a key from within the state
  * @param elem            React element; usually "this"
@@ -228,7 +228,7 @@ export declare function setState<PropT, StateT>(elem: React.Component<PropT, Sta
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function deleteState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function deleteState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): (e: any) => StateT;
 /**
  * Filters a changed state variable so that we only include
  * keys that were changed
@@ -282,7 +282,7 @@ export declare function renderResponse(response: Response, options: {
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export declare function all<T>(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: T) => void;
+export declare function all(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: any) => void;
 /**
  * getNewValue (updater) function that sets the value to that
  * received in the event
@@ -297,7 +297,7 @@ export declare function numberFromEvent(curValue: unknown, e: EventOrValue): num
  * Generator of a getNewValue (updater) function that
  * sets the value to a constant specified ahead of time
  */
-export declare function constant<T>(value: T): (() => T);
+export declare function constant<T>(value: T): () => T;
 /**
  * Generator of a getNewValue (updater) function that
  * deletes a key from within an object
@@ -341,7 +341,7 @@ export declare function setOrNull(curValue: any, e: EventOrValue): string | null
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e: any) => any;
 /**
  * Get an event handler that will set the value of a state
  * based on the "getNewValue" function supplied
@@ -352,7 +352,7 @@ export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function changeState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): (e: any) => StateT;
 /**
  * Get an event handler that will call a function on the React
  * component
@@ -363,7 +363,7 @@ export declare function changeState<PropT, StateT>(elem: React.Component<PropT, 
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return handler that calls a component function
  */
-export declare function call<T extends Object>(elem: T, funcName: keyof T, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function call<T extends Object>(elem: T, funcName: keyof T, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): (...args: any[]) => any;
 /**
  * Get an event handler that will call a function on the React
  * component's props with given arguments
@@ -374,7 +374,7 @@ export declare function call<T extends Object>(elem: T, funcName: keyof T, prefi
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return handler that calls a component function
  */
-export declare function callProp<PropT>(elem: React.Component<PropT>, funcName: keyof PropT, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function callProp<PropT>(elem: React.Component<PropT>, funcName: keyof PropT, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): (...args: any[]) => any;
 /**
  * @deprecated
  * Prefer using `React.createRef` object-based refs instead of this function.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,14 +1,13 @@
 import React from 'react';
-export declare function preventDefault(event: AnyEvent): void;
-export declare function stopPropagation(event: AnyEvent): void;
-export declare function preventDefaultAndBlur<EventT extends AnyEvent>(event: EventT): void;
+export declare function preventDefault(event: Event): void;
+export declare function stopPropagation(event: Event): void;
+export declare function preventDefaultAndBlur(event: React.SyntheticEvent | Event): void;
 /**
  * Many onChange functions either get passed an event (with the changed value
  * in e.target.value) or just the changed value; this disambiguates the two
  */
 declare type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
 declare type EventOrValue = InputChangeEvent | string;
-declare type AnyEvent = React.SyntheticEvent | Event;
 declare type Key = string | number | symbol;
 declare type Keys = Key | Key[];
 declare type TypeSafeKeys<T> = keyof T | [keyof T, ...(string | number)[]];
@@ -48,7 +47,7 @@ export declare const deleteMixed: typeof deleteDeep;
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggle<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function toggle<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -59,7 +58,7 @@ export declare function toggle<StateT>(elem: React.Component<unknown, StateT>, s
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp?: Keys | null, preventDefault?: boolean): any;
+export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp?: Keys | null, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key to either the value given or null
@@ -68,7 +67,7 @@ export declare function toggleProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleValue<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
+export declare function toggleValue<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc
@@ -80,7 +79,7 @@ export declare function toggleValue<StateT>(elem: React.Component<unknown, State
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null, value: any, preventDefault?: boolean): any;
+export declare function togglePropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * state key given by path to either the value passed (if it's
@@ -89,7 +88,7 @@ export declare function togglePropValue<PropT>(elem: React.Component<PropT>, pro
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleFromEvent<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function toggleFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle the value of the given
  * prop key given by path using the propFunc to:
@@ -102,7 +101,7 @@ export declare function toggleFromEvent<StateT>(elem: React.Component<unknown, S
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys, value: any, preventDefault?: boolean): any;
+export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it);
@@ -111,7 +110,7 @@ export declare function togglePropFromEvent<PropT>(elem: React.Component<PropT>,
  * @param stateIndex      path (array or string) of array in state to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMemberFromEvent<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function toggleArrayMemberFromEvent<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given state key (by adding or removing it)
@@ -120,7 +119,7 @@ export declare function toggleArrayMemberFromEvent<StateT>(elem: React.Component
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function toggleArrayMember<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
+export declare function toggleArrayMember<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value is present
  * in an array at the given prop key (by adding or removing it)
@@ -133,7 +132,7 @@ export declare function toggleArrayMember<StateT>(elem: React.Component<unknown,
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
+export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will toggle whether a value (passed in
  * as an argument) should be in an array at the given prop key
@@ -146,7 +145,7 @@ export declare function togglePropArrayMember<PropT>(elem: React.Component<PropT
  *                        if propIndex already points to the array)
  * @param preventDefault  whether to preventDefault
  */
-export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information given
@@ -158,7 +157,7 @@ export declare function togglePropArrayMemberFromEvent<PropT>(elem: React.Compon
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setProp<PropT>(elem: React.Component<any>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function setProp<PropT>(elem: React.Component<any>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
 /**
  * Get an event handler that will set the value of a prop
  * based on the information from an event
@@ -171,7 +170,7 @@ export declare function setProp<PropT>(elem: React.Component<any>, propFunc: str
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
+export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, preventDefault?: boolean): any;
 /**
  * Get an event handler that will set the value of a prop
  * to a set value
@@ -184,7 +183,7 @@ export declare function setPropNumber<PropT>(elem: React.Component<PropT>, propF
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
+export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, value: any, preventDefault?: boolean): any;
 /**
  * Get an event handler that will delete a certain key from a prop
  * and then call an onChange handler; works for both arrays and
@@ -197,7 +196,7 @@ export declare function setPropValue<PropT>(elem: React.Component<PropT>, propFu
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys, preventDefault?: boolean): any;
+export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys, preventDefault?: boolean): any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed
@@ -205,7 +204,7 @@ export declare function deleteProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function update<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function update<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get a function that will update a part of the current element's
  * state based on the stateIndex passed to a numeric (or null) value
@@ -213,7 +212,7 @@ export declare function update<StateT>(elem: React.Component<unknown, StateT>, s
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function updateNumber<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function updateNumber<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Get a function that will set the state for a certain element
  * @param elem            React element; usually "this"
@@ -221,7 +220,7 @@ export declare function updateNumber<StateT>(elem: React.Component<unknown, Stat
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function setState<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
+export declare function setState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, value: any, preventDefault?: boolean): any;
 /**
  * Get a function that will delete a key from within the state
  * @param elem            React element; usually "this"
@@ -229,7 +228,7 @@ export declare function setState<StateT>(elem: React.Component<unknown, StateT>,
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export declare function deleteState<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
+export declare function deleteState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, preventDefault?: boolean): any;
 /**
  * Filters a changed state variable so that we only include
  * keys that were changed
@@ -283,7 +282,7 @@ export declare function renderResponse(response: Response, options: {
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export declare function all<EventT extends AnyEvent>(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: EventT) => void;
+export declare function all<T>(elem: React.Component<any>, handlers: Function[], preventDefault?: boolean): (e: T) => void;
 /**
  * getNewValue (updater) function that sets the value to that
  * received in the event
@@ -342,7 +341,7 @@ export declare function setOrNull(curValue: any, e: EventOrValue): string | null
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: string, propIndex: TypeSafeKeys<PropT>, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc: keyof PropT, propIndex: keyof PropT, indexInProp: Keys | null | undefined, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
  * Get an event handler that will set the value of a state
  * based on the "getNewValue" function supplied
@@ -353,7 +352,7 @@ export declare function changeProp<PropT>(elem: React.Component<PropT>, propFunc
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export declare function changeState<StateT>(elem: React.Component<unknown, StateT>, stateIndex: TypeSafeKeys<StateT>, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function changeState<PropT, StateT>(elem: React.Component<PropT, StateT>, stateIndex: TypeSafeKeys<StateT>, getNewValue: GetNewValueFunc, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
  * Get an event handler that will call a function on the React
  * component
@@ -364,7 +363,7 @@ export declare function changeState<StateT>(elem: React.Component<unknown, State
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return handler that calls a component function
  */
-export declare function call<T extends Object>(elem: T, funcName: TypeSafeKeys<T>, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function call<T extends Object>(elem: T, funcName: keyof T, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
  * Get an event handler that will call a function on the React
  * component's props with given arguments
@@ -375,7 +374,7 @@ export declare function call<T extends Object>(elem: T, funcName: TypeSafeKeys<T
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return handler that calls a component function
  */
-export declare function callProp<PropT>(elem: React.Component<PropT>, funcName: TypeSafeKeys<PropT>, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
+export declare function callProp<PropT>(elem: React.Component<PropT>, funcName: keyof PropT, prefixArgs?: any[] | null, preventDefault?: boolean, extraCacheKey?: any): any;
 /**
  * @deprecated
  * Prefer using `React.createRef` object-based refs instead of this function.

--- a/dist/index.js
+++ b/dist/index.js
@@ -609,7 +609,7 @@ function all(elem, handlers, preventDefault) {
   if (cached) return cached.func;
 
   var func = function func(e) {
-    if (preventDefault) preventDefaultAndBlur(e);
+    if (preventDefault && 'preventDefault' in e) preventDefaultAndBlur(e);
     var origState = elem.state;
 
     for (var _i2 = 0; _i2 !== handlers.length; _i2++) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -62,7 +62,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
-/* eslint-disable prefer-rest-params */
 function preventDefault(event) {
   if (event) event.preventDefault();
 }
@@ -88,12 +87,11 @@ function preventDefaultAndBlur(event) {
 
 
 function getValueFromEventOrValue(e) {
-  return e && e.target ? e.target.value : e;
+  return e && typeof e !== 'string' && 'target' in e ? e.target.value : e;
 }
 
 function normalizeKeys(keys) {
-  if (typeof keys === 'string') keys = keys.split('.');
-  if (!(keys instanceof Array)) keys = [keys];
+  if (!(keys instanceof Array)) return [keys];
   return keys;
 }
 /**
@@ -451,8 +449,8 @@ function setState(elem, stateIndex, value, preventDefault) {
 
 
 function deleteState(elem, stateIndex, preventDefault) {
-  stateIndex = normalizeKeys(stateIndex);
-  return changeState(elem, stateIndex[0], remove(stateIndex.slice(1)), preventDefault, ['remove', stateIndex.slice(1)]);
+  var arrayStateIndex = normalizeKeys(stateIndex);
+  return changeState(elem, stateIndex[0], remove(arrayStateIndex.slice(1)), preventDefault, ['remove', arrayStateIndex.slice(1)]);
 }
 /**
  * Filters a changed state variable so that we only include
@@ -808,7 +806,9 @@ function changeState(elem, stateIndex, getNewValue, preventDefault, extraCacheKe
     if (preventDefault) preventDefaultAndBlur(e);
     var curValue = getMixed(elem.state, stateIndex);
     var newValue = getNewValue(curValue, e);
-    var newState = setMixed(elem.state, stateIndex, newValue);
+    var newState = setMixed(elem.state, stateIndex, newValue); // We need the cast because Partial<StateT> can't be assigned to the
+    // value of setState due to the stricter type-checking
+
     elem.setState(getChanged(elem.state, newState));
     return newState;
   };
@@ -883,8 +883,11 @@ function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
   return func;
 }
 /**
+ * @deprecated
+ * Prefer using `React.createRef` object-based refs instead of this function.
+ * 
  * Get a function to be used with ref={} to register a ref into
- * a variable in the current object
+ * a variable in the current object.
  * @param {Object} elem          React component (usually `this`)
  * @param {String} variableName  Name to save ref (e.g., '_elem' for this._elem)
  * @return {function} handler for ref=}}

--- a/dist/index.js
+++ b/dist/index.js
@@ -46,7 +46,7 @@ exports.changeState = changeState;
 exports.call = call;
 exports.callProp = callProp;
 exports.registerRef = registerRef;
-exports["default"] = exports.deleteMixed = exports.getMixed = exports.setMixed = void 0;
+exports.default = exports.deleteMixed = exports.getMixed = exports.setMixed = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
@@ -58,7 +58,7 @@ var _set2 = _interopRequireDefault(require("lodash/set"));
 
 var _clone2 = _interopRequireDefault(require("lodash/clone"));
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -69,13 +69,22 @@ function preventDefault(event) {
 function stopPropagation(event) {
   if (event) event.stopPropagation();
 }
+/**
+ * This function can handle any type gracefully, so calling functions don't
+ * have to check if the input is an event. It'll do nothing if the input isn't
+ * an event.
+ */
 
-function preventDefaultAndBlur(event) {
-  if (event && event.preventDefault) {
+
+function preventDefaultAndBlur(eventOrAny) {
+  if (!(eventOrAny && eventOrAny.preventDefault)) return;
+  var event = eventOrAny;
+
+  if (event && eventOrAny.preventDefault) {
     event.preventDefault();
     event.stopPropagation();
 
-    if (event.target) {
+    if (event.target && 'blur' in event.target) {
       event.target.blur();
     }
   }
@@ -106,7 +115,7 @@ function normalizeKeys(keys) {
 
 function set(obj, keys, value, withType) {
   keys = normalizeKeys(keys);
-  var curValue = keys && keys.length !== 0 ? (0, _get2["default"])(obj, keys) : obj;
+  var curValue = keys && keys.length !== 0 ? (0, _get2.default)(obj, keys) : obj;
 
   if (curValue === value) {
     // Prevent unneeded changes
@@ -116,18 +125,18 @@ function set(obj, keys, value, withType) {
   var keysSoFar = []; // Clone parents so that we still have good behavior
   // with PureRenderMixin
 
-  obj = (0, _clone2["default"])(obj);
+  obj = (0, _clone2.default)(obj);
 
   for (var i = 0; i !== keys.length - 1; i++) {
     var key = keys[i];
     keysSoFar.push(key);
-    (0, _set2["default"])(obj, keysSoFar, (0, _clone2["default"])((0, _get2["default"])(obj, keysSoFar)));
+    (0, _set2.default)(obj, keysSoFar, (0, _clone2.default)((0, _get2.default)(obj, keysSoFar)));
   }
 
   if (!withType) {
-    (0, _set2["default"])(obj, keys, value);
+    (0, _set2.default)(obj, keys, value);
   } else {
-    (0, _setWith2["default"])(obj, keys, value, withType);
+    (0, _setWith2.default)(obj, keys, value, withType);
   }
 
   return obj;
@@ -142,7 +151,7 @@ function set(obj, keys, value, withType) {
 
 
 function get(obj, keys) {
-  return (0, _get2["default"])(obj, keys);
+  return (0, _get2.default)(obj, keys);
 }
 /**
  * Delete a variable deep in a map that's potentially partly
@@ -154,22 +163,22 @@ function get(obj, keys) {
 
 
 function deleteDeep(obj, keys) {
-  keys = normalizeKeys(keys);
+  var normalizedKeys = normalizeKeys(keys);
   var keysSoFar = []; // Clone parents so that we still have good behavior
   // with PureRenderMixin
 
-  obj = (0, _clone2["default"])(obj);
+  obj = (0, _clone2.default)(obj);
 
-  for (var i = 0; i !== keys.length - 1; i++) {
-    var key = keys[i];
+  for (var i = 0; i !== normalizedKeys.length - 1; i++) {
+    var key = normalizedKeys[i];
     keysSoFar.push(key);
-    (0, _set2["default"])(obj, keysSoFar, (0, _clone2["default"])((0, _get2["default"])(obj, keysSoFar)));
+    (0, _set2.default)(obj, keysSoFar, (0, _clone2.default)((0, _get2.default)(obj, keysSoFar)));
   } // Use the second-to-last key to get the object to delete in
 
 
-  var deleteObjKey = keys.slice(0, -1);
-  var deleteObj = deleteObjKey.length !== 0 ? (0, _get2["default"])(obj, deleteObjKey) : obj;
-  var deleteKey = keys[keys.length - 1];
+  var deleteObjKey = normalizedKeys.slice(0, -1);
+  var deleteObj = deleteObjKey.length !== 0 ? (0, _get2.default)(obj, deleteObjKey) : obj;
+  var deleteKey = normalizedKeys[normalizedKeys.length - 1];
 
   if (deleteObj instanceof Array) {
     if (typeof deleteKey !== 'number') {
@@ -488,7 +497,7 @@ function getThen(elem) {
   var dataKey = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'data';
   // Avoid creating new functions if possible
   var cacheKey = ['__cache', JSON.stringify(['getThen', responseKey, loadingKey])];
-  var func = (0, _get2["default"])(elem, cacheKey);
+  var func = (0, _get2.default)(elem, cacheKey);
   if (func) return func;
 
   func = function func(data) {
@@ -503,7 +512,7 @@ function getThen(elem) {
     elem.setState(newState);
   };
 
-  (0, _setWith2["default"])(elem, cacheKey, func, Object);
+  (0, _setWith2.default)(elem, cacheKey, func, Object);
   return func;
 }
 /**
@@ -522,7 +531,7 @@ function getCatch(elem) {
   var cacheKey = ['__cache', JSON.stringify(['getCatch', responseKey, loadingKey])];
   responseKey = responseKey || 'response';
   loadingKey = loadingKey || 'loading';
-  var cached = (0, _get2["default"])(elem, cacheKey);
+  var cached = (0, _get2.default)(elem, cacheKey);
   if (cached) return cached;
 
   var func = function func(err) {
@@ -537,7 +546,7 @@ function getCatch(elem) {
     elem.setState(newState);
   };
 
-  (0, _setWith2["default"])(elem, cacheKey, func, Object);
+  (0, _setWith2.default)(elem, cacheKey, func, Object);
   return func;
 }
 /**
@@ -561,11 +570,11 @@ function renderResponse(response, options) {
   var errorsOnly = !!options.errorsOnly;
   if (!response) return null;
   if (response.success && errorsOnly) return null;
-  return response && response.messages && _react["default"].createElement("div", {
+  return response && response.messages && _react.default.createElement("div", {
     className: "".concat(type, " ").concat(type, "-") + (response.success ? 'success' : 'danger') + (additionalClasses ? ' ' + additionalClasses : '') + (onClick ? ' wa-link' : ''),
     onClick: onClick
   }, response.messages.map(function (message, i) {
-    return _react["default"].createElement("p", {
+    return _react.default.createElement("p", {
       key: i
     }, message);
   }));
@@ -583,7 +592,7 @@ function renderResponse(response, options) {
  */
 function all(elem, handlers, preventDefault) {
   var cacheKey = ['__cache', 'all'];
-  var allCached = (0, _get2["default"])(elem, cacheKey) || []; // Try to find one in the cache by deep comparisons
+  var allCached = (0, _get2.default)(elem, cacheKey) || []; // Try to find one in the cache by deep comparisons
 
   var cached = null;
 
@@ -610,10 +619,7 @@ function all(elem, handlers, preventDefault) {
   if (cached) return cached.func;
 
   var func = function func(e) {
-    if (preventDefault && 'preventDefault' in e) {
-      preventDefaultAndBlur(e);
-    }
-
+    if (preventDefault) preventDefaultAndBlur(e);
     var origState = elem.state;
 
     for (var _i2 = 0; _i2 !== handlers.length; _i2++) {
@@ -632,7 +638,7 @@ function all(elem, handlers, preventDefault) {
     func: func
   };
   allCached.push(cached);
-  (0, _set2["default"])(elem, cacheKey, allCached);
+  (0, _set2.default)(elem, cacheKey, allCached);
   return func;
 }
 /**
@@ -760,7 +766,7 @@ function setOrNull(curValue, e) {
 
 function changeProp(elem, propFunc, propIndex, indexInProp, getNewValue, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['changeProp', propFunc, propIndex, indexInProp, preventDefault, extraCacheKey])];
-  var func = (0, _get2["default"])(elem, cacheKey);
+  var func = (0, _get2.default)(elem, cacheKey);
   if (func) return func;
 
   func = function func(e) {
@@ -786,7 +792,7 @@ function changeProp(elem, propFunc, propIndex, indexInProp, getNewValue, prevent
     return newPropObj;
   };
 
-  (0, _setWith2["default"])(elem, cacheKey, func, Object);
+  (0, _setWith2.default)(elem, cacheKey, func, Object);
   return func;
 }
 /**
@@ -803,7 +809,7 @@ function changeProp(elem, propFunc, propIndex, indexInProp, getNewValue, prevent
 
 function changeState(elem, stateIndex, getNewValue, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['changeState', stateIndex, preventDefault, extraCacheKey])];
-  var func = (0, _get2["default"])(elem, cacheKey);
+  var func = (0, _get2.default)(elem, cacheKey);
   if (func) return func;
 
   func = function func(e) {
@@ -817,7 +823,7 @@ function changeState(elem, stateIndex, getNewValue, preventDefault, extraCacheKe
     return newState;
   };
 
-  (0, _setWith2["default"])(elem, cacheKey, func, Object);
+  (0, _setWith2.default)(elem, cacheKey, func, Object);
   return func;
 }
 /**
@@ -834,7 +840,7 @@ function changeState(elem, stateIndex, getNewValue, preventDefault, extraCacheKe
 
 function call(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['call', funcName, prefixArgs, preventDefault, extraCacheKey])];
-  var func = (0, _get2["default"])(elem, cacheKey);
+  var func = (0, _get2.default)(elem, cacheKey);
   if (func) return func;
 
   func = function func() {
@@ -844,7 +850,7 @@ function call(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
 
     if (preventDefault && args[0]) preventDefaultAndBlur(args[0]);
     var callArgs = (prefixArgs || []).concat(args);
-    var func = (0, _get2["default"])(elem, funcName);
+    var func = (0, _get2.default)(elem, funcName);
 
     if (func) {
       return func.apply(elem, callArgs);
@@ -853,7 +859,7 @@ function call(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
     }
   };
 
-  (0, _setWith2["default"])(elem, cacheKey, func, Object);
+  (0, _setWith2.default)(elem, cacheKey, func, Object);
   return func;
 }
 /**
@@ -870,7 +876,7 @@ function call(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
 
 function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['callProp', funcName, prefixArgs, preventDefault, extraCacheKey])];
-  var func = (0, _get2["default"])(elem, cacheKey);
+  var func = (0, _get2.default)(elem, cacheKey);
   if (func) return func;
 
   func = function func() {
@@ -880,7 +886,7 @@ function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
 
     if (preventDefault && args[0]) preventDefaultAndBlur(args[0]);
     var callArgs = (prefixArgs || []).concat(args);
-    var func = (0, _get2["default"])(elem.props, funcName);
+    var func = (0, _get2.default)(elem.props, funcName);
 
     if (func) {
       return func.apply(elem, callArgs);
@@ -889,7 +895,7 @@ function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
     }
   };
 
-  (0, _setWith2["default"])(elem, cacheKey, func, Object);
+  (0, _setWith2.default)(elem, cacheKey, func, Object);
   return func;
 }
 /**
@@ -906,14 +912,14 @@ function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
 
 function registerRef(elem, variableName) {
   var cacheKey = ['__cache', JSON.stringify(['registerRef', variableName])];
-  var func = (0, _get2["default"])(elem, cacheKey);
+  var func = (0, _get2.default)(elem, cacheKey);
   if (func) return func;
 
   func = function func(pageElem) {
-    (0, _setWith2["default"])(elem, variableName, pageElem, Object);
+    (0, _setWith2.default)(elem, variableName, pageElem, Object);
   };
 
-  (0, _setWith2["default"])(elem, cacheKey, func, Object);
+  (0, _setWith2.default)(elem, cacheKey, func, Object);
   return func;
 }
 
@@ -964,5 +970,5 @@ var _default = {
   get: get,
   deleteDeep: deleteDeep
 };
-exports["default"] = _default;
+exports.default = _default;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -906,10 +906,10 @@ function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
 
 function registerRef(elem, variableName) {
   var cacheKey = ['__cache', JSON.stringify(['registerRef', variableName])];
-  var cached = (0, _get2["default"])(elem, cacheKey);
-  if (cached) return cached;
+  var func = (0, _get2["default"])(elem, cacheKey);
+  if (func) return func;
 
-  var func = function func(pageElem) {
+  func = function func(pageElem) {
     (0, _setWith2["default"])(elem, variableName, pageElem, Object);
   };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -488,10 +488,10 @@ function getThen(elem) {
   var dataKey = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'data';
   // Avoid creating new functions if possible
   var cacheKey = ['__cache', JSON.stringify(['getThen', responseKey, loadingKey])];
-  var cached = (0, _get2["default"])(elem, cacheKey);
-  if (cached) return cached;
+  var func = (0, _get2["default"])(elem, cacheKey);
+  if (func) return func;
 
-  var func = function func(data) {
+  func = function func(data) {
     var newState = {};
     newState[loadingKey] = false;
     newState[responseKey] = data;
@@ -570,6 +570,9 @@ function renderResponse(response, options) {
     }, message);
   }));
 }
+/** Item within the array for the `all()` cache */
+
+
 /**
  * Get an event handler that does all of the entries
  * supplied
@@ -578,8 +581,6 @@ function renderResponse(response, options) {
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-
-
 function all(elem, handlers, preventDefault) {
   var cacheKey = ['__cache', 'all'];
   var allCached = (0, _get2["default"])(elem, cacheKey) || []; // Try to find one in the cache by deep comparisons
@@ -609,7 +610,10 @@ function all(elem, handlers, preventDefault) {
   if (cached) return cached.func;
 
   var func = function func(e) {
-    if (preventDefault && 'preventDefault' in e) preventDefaultAndBlur(e);
+    if (preventDefault && 'preventDefault' in e) {
+      preventDefaultAndBlur(e);
+    }
+
     var origState = elem.state;
 
     for (var _i2 = 0; _i2 !== handlers.length; _i2++) {
@@ -756,10 +760,10 @@ function setOrNull(curValue, e) {
 
 function changeProp(elem, propFunc, propIndex, indexInProp, getNewValue, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['changeProp', propFunc, propIndex, indexInProp, preventDefault, extraCacheKey])];
-  var cached = (0, _get2["default"])(elem, cacheKey);
-  if (cached) return cached;
+  var func = (0, _get2["default"])(elem, cacheKey);
+  if (func) return func;
 
-  var func = function func(e) {
+  func = function func(e) {
     if (preventDefault) preventDefaultAndBlur(e);
     var newPropObj = null;
 
@@ -799,10 +803,10 @@ function changeProp(elem, propFunc, propIndex, indexInProp, getNewValue, prevent
 
 function changeState(elem, stateIndex, getNewValue, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['changeState', stateIndex, preventDefault, extraCacheKey])];
-  var cached = (0, _get2["default"])(elem, cacheKey);
-  if (cached) return cached;
+  var func = (0, _get2["default"])(elem, cacheKey);
+  if (func) return func;
 
-  var func = function func(e) {
+  func = function func(e) {
     if (preventDefault) preventDefaultAndBlur(e);
     var curValue = getMixed(elem.state, stateIndex);
     var newValue = getNewValue(curValue, e);
@@ -830,11 +834,14 @@ function changeState(elem, stateIndex, getNewValue, preventDefault, extraCacheKe
 
 function call(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['call', funcName, prefixArgs, preventDefault, extraCacheKey])];
-  var cached = (0, _get2["default"])(elem, cacheKey);
-  if (cached) return cached;
+  var func = (0, _get2["default"])(elem, cacheKey);
+  if (func) return func;
 
-  var func = function func() {
-    var args = Array.prototype.slice.call(arguments);
+  func = function func() {
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
     if (preventDefault && args[0]) preventDefaultAndBlur(args[0]);
     var callArgs = (prefixArgs || []).concat(args);
     var func = (0, _get2["default"])(elem, funcName);
@@ -863,11 +870,14 @@ function call(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
 
 function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
   var cacheKey = ['__cache', JSON.stringify(['callProp', funcName, prefixArgs, preventDefault, extraCacheKey])];
-  var cached = (0, _get2["default"])(elem, cacheKey);
-  if (cached) return cached;
+  var func = (0, _get2["default"])(elem, cacheKey);
+  if (func) return func;
 
-  var func = function func() {
-    var args = Array.prototype.slice.call(arguments);
+  func = function func() {
+    for (var _len2 = arguments.length, args = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+      args[_key2] = arguments[_key2];
+    }
+
     if (preventDefault && args[0]) preventDefaultAndBlur(args[0]);
     var callArgs = (prefixArgs || []).concat(args);
     var func = (0, _get2["default"])(elem.props, funcName);
@@ -885,7 +895,7 @@ function callProp(elem, funcName, prefixArgs, preventDefault, extraCacheKey) {
 /**
  * @deprecated
  * Prefer using `React.createRef` object-based refs instead of this function.
- * 
+ *
  * Get a function to be used with ref={} to register a ref into
  * a variable in the current object.
  * @param {Object} elem          React component (usually `this`)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/react": "^16.7.7",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.1",
-    "typescript": "^3.1.6"
+    "typescript": "^3.7.2"
   },
   "dependencies": {
     "lodash": "~4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-updaters",
-  "version": "2.1.5",
+  "version": "3.0.0",
   "description": "Updaters and React handlers to change state and props preserving immutable semantics",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -736,7 +736,7 @@ export function renderResponse(
 /** Item within the array for the `all()` cache */
 interface AllCacheItem {
   args: [Function[], boolean | undefined];
-  func: (e: any) => void;
+  func: (e?: any) => void;
 }
 
 /**
@@ -779,7 +779,7 @@ export function all(
   }
   if (cached) return cached.func;
 
-  const func = function(e: any) {
+  const func = function(e?: any) {
     if (preventDefault && 'preventDefault' in e) {
       preventDefaultAndBlur(e);
     }
@@ -936,10 +936,10 @@ export function changeProp<PropT>(
       extraCacheKey,
     ]),
   ];
-  let func: (e: any) => any = _get(elem, cacheKey);
+  let func: (e?: any) => any = _get(elem, cacheKey);
   if (func) return func;
 
-  func = function(e: any) {
+  func = function(e?: any) {
     if (preventDefault) preventDefaultAndBlur(e);
 
     let newPropObj = null;
@@ -985,10 +985,10 @@ export function changeState<PropT, StateT>(
     '__cache',
     JSON.stringify(['changeState', stateIndex, preventDefault, extraCacheKey]),
   ];
-  let func: (e: any) => StateT = _get(elem, cacheKey);
+  let func: (e?: any) => StateT = _get(elem, cacheKey);
   if (func) return func;
 
-  func = function(e: any) {
+  func = function(e?: any) {
     if (preventDefault) preventDefaultAndBlur(e);
 
     const curValue = getMixed(elem.state, stateIndex);
@@ -1109,10 +1109,10 @@ export function callProp<PropT>(
  */
 export function registerRef<T extends Object>(elem: T, variableName: Keys) {
   const cacheKey = ['__cache', JSON.stringify(['registerRef', variableName])];
-  const cached = _get(elem, cacheKey);
-  if (cached) return cached;
+  let func: (pageElem: any) => void = _get(elem, cacheKey);
+  if (func) return func;
 
-  const func = function(pageElem: any) {
+  func = function(pageElem: any) {
     _setWith(elem, variableName, pageElem, Object);
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -144,8 +144,8 @@ export const deleteMixed = deleteDeep;
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export function toggle<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function toggle<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   preventDefault?: boolean,
 ) {
@@ -188,8 +188,8 @@ export function toggleProp<PropT>(
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export function toggleValue<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function toggleValue<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   value: any,
   preventDefault?: boolean,
@@ -238,8 +238,8 @@ export function togglePropValue<PropT>(
  * @param stateIndex      path of variable in state to toggle (array or string)
  * @param preventDefault  whether to preventDefault
  */
-export function toggleFromEvent<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function toggleFromEvent<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   preventDefault?: boolean,
 ) {
@@ -285,8 +285,8 @@ export function togglePropFromEvent<PropT>(
  * @param stateIndex      path (array or string) of array in state to toggle
  * @param preventDefault  whether to preventDefault
  */
-export function toggleArrayMemberFromEvent<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function toggleArrayMemberFromEvent<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   preventDefault?: boolean,
 ) {
@@ -307,8 +307,8 @@ export function toggleArrayMemberFromEvent<StateT>(
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export function toggleArrayMember<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function toggleArrayMember<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   value: any,
   preventDefault?: boolean,
@@ -510,8 +510,8 @@ export function deleteProp<PropT>(
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export function update<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function update<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   preventDefault?: boolean,
 ) {
@@ -525,8 +525,8 @@ export function update<StateT>(
  * @param stateIndex      path of variable in state to set
  * @param preventDefault  whether to preventDefault on the event
  */
-export function updateNumber<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function updateNumber<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   preventDefault?: boolean,
 ) {
@@ -546,8 +546,8 @@ export function updateNumber<StateT>(
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export function setState<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function setState<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   value: any,
   preventDefault?: boolean,
@@ -565,8 +565,8 @@ export function setState<StateT>(
  * @param value           value to set the variable to
  * @param preventDefault  whether to preventDefault on the event
  */
-export function deleteState<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function deleteState<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   preventDefault?: boolean,
 ) {
@@ -966,8 +966,8 @@ export function changeProp<PropT>(
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export function changeState<StateT>(
-  elem: React.Component<unknown, StateT>,
+export function changeState<PropT, StateT>(
+  elem: React.Component<PropT, StateT>,
   stateIndex: TypeSafeKeys<StateT>,
   getNewValue: GetNewValueFunc,
   preventDefault?: boolean,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -411,7 +411,7 @@ export function togglePropArrayMemberFromEvent<
  * @return function to handle events or values being changed
  */
 export function setProp<PropT, PropK extends keyof PropT>(
-  elem: React.Component<any>,
+  elem: React.Component<PropT>,
   propFunc: keyof PropT,
   propIndex: PropK,
   indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -164,8 +164,8 @@ export function toggle<PropT, StateT>(
  */
 export function toggleProp<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp?: Keys | null,
   preventDefault?: boolean,
 ) {
@@ -213,8 +213,8 @@ export function toggleValue<PropT, StateT>(
  */
 export function togglePropValue<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys | null,
   value: any,
   preventDefault?: boolean,
@@ -260,8 +260,8 @@ export function toggleFromEvent<PropT, StateT>(
  */
 export function togglePropFromEvent<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys,
   value: any,
   preventDefault?: boolean,
@@ -336,8 +336,8 @@ export function toggleArrayMember<PropT, StateT>(
  */
 export function togglePropArrayMember<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys | null | undefined,
   value: any,
   preventDefault?: boolean,
@@ -367,8 +367,8 @@ export function togglePropArrayMember<PropT>(
  */
 export function togglePropArrayMemberFromEvent<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys | null | undefined,
   preventDefault?: boolean,
 ) {
@@ -396,8 +396,8 @@ export function togglePropArrayMemberFromEvent<PropT>(
  */
 export function setProp<PropT>(
   elem: React.Component<any>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys | null | undefined,
   preventDefault?: boolean,
 ) {
@@ -426,8 +426,8 @@ export function setProp<PropT>(
  */
 export function setPropNumber<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys | null | undefined,
   preventDefault?: boolean,
 ) {
@@ -456,8 +456,8 @@ export function setPropNumber<PropT>(
  */
 export function setPropValue<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys | null | undefined,
   value: any,
   preventDefault?: boolean,
@@ -487,8 +487,8 @@ export function setPropValue<PropT>(
  */
 export function deleteProp<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys,
   preventDefault?: boolean,
 ) {
@@ -741,7 +741,7 @@ export function renderResponse(
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export function all<T extends React.SyntheticEvent | Event>(
+export function all<T>(
   elem: React.Component<any>,
   handlers: Function[],
   preventDefault?: boolean,
@@ -774,7 +774,7 @@ export function all<T extends React.SyntheticEvent | Event>(
   if (cached) return cached.func as (e: T) => void;
 
   const func = function(e: T) {
-    if (preventDefault) preventDefaultAndBlur(e);
+    if (preventDefault && 'preventDefault' in e) preventDefaultAndBlur(e as any);
     const origState = elem.state;
 
     for (let i = 0; i !== handlers.length; i++) {
@@ -910,8 +910,8 @@ export function setOrNull(curValue: any, e: EventOrValue) {
  */
 export function changeProp<PropT>(
   elem: React.Component<PropT>,
-  propFunc: string,
-  propIndex: TypeSafeKeys<PropT>,
+  propFunc: keyof PropT,
+  propIndex: keyof PropT,
   indexInProp: Keys | null | undefined,
   getNewValue: GetNewValueFunc,
   preventDefault?: boolean,
@@ -948,7 +948,7 @@ export function changeProp<PropT>(
       newPropObj = getNewValue(null, e);
     }
 
-    elem.props[propFunc](newPropObj);
+    (elem.props[propFunc] as any)(newPropObj);
     return newPropObj;
   };
 
@@ -1009,7 +1009,7 @@ export function changeState<PropT, StateT>(
  */
 export function call<T extends Object>(
   elem: T,
-  funcName: TypeSafeKeys<T>,
+  funcName: keyof T,
   prefixArgs?: any[] | null,
   preventDefault?: boolean,
   extraCacheKey?: any,
@@ -1035,7 +1035,7 @@ export function call<T extends Object>(
 
     const func = _get(elem, funcName);
     if (func) {
-      return func.apply(elem, callArgs);
+      return (func as any).apply(elem, callArgs);
     } else {
       return null;
     }
@@ -1057,7 +1057,7 @@ export function call<T extends Object>(
  */
 export function callProp<PropT>(
   elem: React.Component<PropT>,
-  funcName: TypeSafeKeys<PropT>,
+  funcName: keyof PropT,
   prefixArgs?: any[] | null,
   preventDefault?: boolean,
   extraCacheKey?: any,
@@ -1083,7 +1083,7 @@ export function callProp<PropT>(
 
     const func = _get(elem.props, funcName);
     if (func) {
-      return func.apply(elem, callArgs);
+      return (func as any).apply(elem, callArgs);
     } else {
       return null;
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,15 +4,15 @@ import _get from 'lodash/get';
 import _set from 'lodash/set';
 import _clone from 'lodash/clone';
 
-export function preventDefault(event: Event) {
+export function preventDefault(event: AnyEvent) {
   if (event) event.preventDefault();
 }
 
-export function stopPropagation(event: Event) {
+export function stopPropagation(event: AnyEvent) {
   if (event) event.stopPropagation();
 }
 
-export function preventDefaultAndBlur(event: Event | InputChangeEvent) {
+export function preventDefaultAndBlur<EventT extends AnyEvent>(event: EventT) {
   if (event && event.preventDefault) {
     event.preventDefault();
     event.stopPropagation();
@@ -31,6 +31,7 @@ type EventOrValue = InputChangeEvent | string;
 function getValueFromEventOrValue(e: EventOrValue) {
   return e && typeof e !== 'string' && 'target' in e ? e.target.value : e;
 }
+type AnyEvent = React.SyntheticEvent | Event;
 
 type Key = string | number | symbol;
 type Keys = Key | Key[];
@@ -741,7 +742,7 @@ export function renderResponse(
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export function all(
+export function all<EventT extends AnyEvent>(
   elem: React.Component<any>,
   handlers: Function[],
   preventDefault?: boolean,
@@ -771,9 +772,9 @@ export function all(
       break;
     }
   }
-  if (cached) return cached.func as (e: Event) => void;
+  if (cached) return cached.func as (e: EventT) => void;
 
-  const func = function(e: Event) {
+  const func = function(e: EventT) {
     if (preventDefault) preventDefaultAndBlur(e);
     const origState = elem.state;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,15 +4,15 @@ import _get from 'lodash/get';
 import _set from 'lodash/set';
 import _clone from 'lodash/clone';
 
-export function preventDefault(event: AnyEvent) {
+export function preventDefault(event: Event) {
   if (event) event.preventDefault();
 }
 
-export function stopPropagation(event: AnyEvent) {
+export function stopPropagation(event: Event) {
   if (event) event.stopPropagation();
 }
 
-export function preventDefaultAndBlur<EventT extends AnyEvent>(event: EventT) {
+export function preventDefaultAndBlur(event: React.SyntheticEvent | Event) {
   if (event && event.preventDefault) {
     event.preventDefault();
     event.stopPropagation();
@@ -31,7 +31,6 @@ type EventOrValue = InputChangeEvent | string;
 function getValueFromEventOrValue(e: EventOrValue) {
   return e && typeof e !== 'string' && 'target' in e ? e.target.value : e;
 }
-type AnyEvent = React.SyntheticEvent | Event;
 
 type Key = string | number | symbol;
 type Keys = Key | Key[];
@@ -742,7 +741,7 @@ export function renderResponse(
  * @param preventDefault  whether to call preventDefault
  * @return event handler
  */
-export function all<EventT extends AnyEvent>(
+export function all<T extends React.SyntheticEvent | Event>(
   elem: React.Component<any>,
   handlers: Function[],
   preventDefault?: boolean,
@@ -772,9 +771,9 @@ export function all<EventT extends AnyEvent>(
       break;
     }
   }
-  if (cached) return cached.func as (e: EventT) => void;
+  if (cached) return cached.func as (e: T) => void;
 
-  const func = function(e: EventT) {
+  const func = function(e: T) {
     if (preventDefault) preventDefaultAndBlur(e);
     const origState = elem.state;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,102 +42,9 @@ function getValueFromEventOrValue(e: EventOrValue) {
 
 type Key = string | number | symbol;
 
-/** This complex type allows us to typecheck arrays of paths up to 5 deep */
-type TypeSafeKeys<T, T1 extends keyof T = keyof T> = T1 | TypeSafeKeysArray<T>;
-type TypeSafeKeysArray<
-  T,
-  T1 extends keyof T = keyof T,
-  T2 extends keyof T[T1] = keyof T[T1],
-  T3 extends keyof T[T1][T2] = keyof T[T1][T2],
-  T4 extends keyof T[T1][T2][T3] = keyof T[T1][T2][T3],
-  T5 extends keyof T[T1][T2][T3][T4] = keyof T[T1][T2][T3][T4]
-> =
-  | TypeSafeKeysArray1<T, T1>
-  | TypeSafeKeysArray2<T, T1, T2>
-  | TypeSafeKeysArray3<T, T1, T2, T3>
-  | TypeSafeKeysArray4<T, T1, T2, T3, T4>
-  | TypeSafeKeysArray5Plus<T, T1, T2, T3, T4, T5>;
-type TypeSafeKeysArray1<T, T1 extends keyof T> = [T1];
-type TypeSafeKeysArray2<T, T1 extends keyof T, T2 extends keyof T[T1]> = [
-  T1,
-  T2,
-];
-type TypeSafeKeysArray3<
-  T,
-  T1 extends keyof T,
-  T2 extends keyof T[T1],
-  T3 extends keyof T[T1][T2]
-> = [T1, T2, T3];
-type TypeSafeKeysArray4<
-  T,
-  T1 extends keyof T,
-  T2 extends keyof T[T1],
-  T3 extends keyof T[T1][T2],
-  T4 extends keyof T[T1][T2][T3]
-> = [T1, T2, T3, T4];
-type TypeSafeKeysArray5Plus<
-  T,
-  T1 extends keyof T,
-  T2 extends keyof T[T1],
-  T3 extends keyof T[T1][T2],
-  T4 extends keyof T[T1][T2][T3],
-  T5 extends keyof T[T1][T2][T3][T4]
-> = [T1, T2, T3, T4, T5, ...Key[]];
-
-/**
- * Like TypeSafeKeys, but for `indexInProp` which excludes the prop itself.
- * Typechecks keys (including array keys) up to 5 levels deep.
- */
-type TypeSafeIndexInProp<
-  T,
-  PropK extends keyof T = keyof T,
-  T1 extends keyof T[PropK] = keyof T[PropK],
-  T2 extends keyof T[PropK][T1] = keyof T[PropK][T1],
-  T3 extends keyof T[PropK][T1][T2] = keyof T[PropK][T1][T2],
-  T4 extends keyof T[PropK][T1][T2][T3] = keyof T[PropK][T1][T2][T3],
-  T5 extends keyof T[PropK][T1][T2][T3][T4] = keyof T[PropK][T1][T2][T3][T4]
-> =
-  | T1
-  | TypeSafeIndexInPropArray1<T, PropK, T1>
-  | TypeSafeIndexInPropArray2<T, PropK, T1, T2>
-  | TypeSafeIndexInPropArray3<T, PropK, T1, T2, T3>
-  | TypeSafeIndexInPropArray4<T, PropK, T1, T2, T3, T4>
-  | TypeSafeIndexInPropArray5Plus<T, PropK, T1, T2, T3, T4, T5>;
-type TypeSafeIndexInPropArray1<
-  T,
-  PropK extends keyof T,
-  T1 extends keyof T[PropK]
-> = [T1];
-type TypeSafeIndexInPropArray2<
-  T,
-  PropK extends keyof T,
-  T1 extends keyof T[PropK],
-  T2 extends keyof T[PropK][T1]
-> = [T1, T2];
-type TypeSafeIndexInPropArray3<
-  T,
-  PropK extends keyof T,
-  T1 extends keyof T[PropK],
-  T2 extends keyof T[PropK][T1],
-  T3 extends keyof T[PropK][T1][T2]
-> = [T1, T2, T3];
-type TypeSafeIndexInPropArray4<
-  T,
-  PropK extends keyof T,
-  T1 extends keyof T[PropK],
-  T2 extends keyof T[PropK][T1],
-  T3 extends keyof T[PropK][T1][T2],
-  T4 extends keyof T[PropK][T1][T2][T3]
-> = [T1, T2, T3, T4];
-type TypeSafeIndexInPropArray5Plus<
-  T,
-  PropK extends keyof T,
-  T1 extends keyof T[PropK],
-  T2 extends keyof T[PropK][T1],
-  T3 extends keyof T[PropK][T1][T2],
-  T4 extends keyof T[PropK][T1][T2][T3],
-  T5 extends keyof T[PropK][T1][T2][T3][T4]
-> = [T1, T2, T3, T4, T5, ...Key[]];
+/** Type-checks a string key or the first key in an array of keys */
+type TypeSafeKeys<T> = keyof T | TypeSafeKeysArray<T>;
+type TypeSafeKeysArray<T> = [keyof T, ...Key[]];
 
 type GetNewValueFunc = (curValue: unknown, event: EventOrValue) => unknown;
 
@@ -268,11 +175,11 @@ export function toggle<PropT, StateT>(
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export function toggleProp<PropT>(
+export function toggleProp<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp?: TypeSafeIndexInProp<PropT> | null,
+  propIndex: PropK,
+  indexInProp?: TypeSafeKeys<PropT[PropK]> | null,
   preventDefault?: boolean,
 ) {
   return changeProp(
@@ -317,11 +224,11 @@ export function toggleValue<PropT, StateT>(
  * @param value           value to set (if it's not already the current value)
  * @param preventDefault  whether to preventDefault
  */
-export function togglePropValue<PropT>(
+export function togglePropValue<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT> | null,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]> | null,
   value: any,
   preventDefault?: boolean,
 ) {
@@ -364,11 +271,11 @@ export function toggleFromEvent<PropT, StateT>(
  * @param indexInProp     index within the prop of the value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export function togglePropFromEvent<PropT>(
+export function togglePropFromEvent<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT>,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]>,
   value: any,
   preventDefault?: boolean,
 ) {
@@ -440,11 +347,11 @@ export function toggleArrayMember<PropT, StateT>(
  * @param value           value to toggle
  * @param preventDefault  whether to preventDefault
  */
-export function togglePropArrayMember<PropT>(
+export function togglePropArrayMember<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT> | null | undefined,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined,
   value: any,
   preventDefault?: boolean,
 ) {
@@ -471,11 +378,14 @@ export function togglePropArrayMember<PropT>(
  *                        if propIndex already points to the array)
  * @param preventDefault  whether to preventDefault
  */
-export function togglePropArrayMemberFromEvent<PropT>(
+export function togglePropArrayMemberFromEvent<
+  PropT,
+  PropK extends keyof PropT
+>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT> | null | undefined,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined,
   preventDefault?: boolean,
 ) {
   return changeProp(
@@ -500,11 +410,11 @@ export function togglePropArrayMemberFromEvent<PropT>(
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export function setProp<PropT>(
+export function setProp<PropT, PropK extends keyof PropT>(
   elem: React.Component<any>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT> | null | undefined,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined,
   preventDefault?: boolean,
 ) {
   return changeProp(
@@ -530,11 +440,11 @@ export function setProp<PropT>(
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export function setPropNumber<PropT>(
+export function setPropNumber<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT> | null | undefined,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined,
   preventDefault?: boolean,
 ) {
   return changeProp(
@@ -560,11 +470,11 @@ export function setPropNumber<PropT>(
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export function setPropValue<PropT>(
+export function setPropValue<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT> | null | undefined,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined,
   value: any,
   preventDefault?: boolean,
 ) {
@@ -591,11 +501,11 @@ export function setPropValue<PropT>(
  * @param preventDefault  whether to preventDefault
  * @return function to handle events or values being changed
  */
-export function deleteProp<PropT>(
+export function deleteProp<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT>,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]>,
   preventDefault?: boolean,
 ) {
   return changeProp(
@@ -1020,11 +930,11 @@ export function setOrNull(curValue: any, e: EventOrValue) {
  * @param extraCacheKey   extra data for the cache key (e.g., for data in changeFunc)
  * @return function to handle events or values being changed
  */
-export function changeProp<PropT>(
+export function changeProp<PropT, PropK extends keyof PropT>(
   elem: React.Component<PropT>,
   propFunc: keyof PropT,
-  propIndex: keyof PropT,
-  indexInProp: TypeSafeIndexInProp<PropT> | null | undefined,
+  propIndex: PropK,
+  indexInProp: TypeSafeKeys<PropT[PropK]> | null | undefined,
   getNewValue: GetNewValueFunc,
   preventDefault?: boolean,
   extraCacheKey?: any,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,164 +3,182 @@
 
 
 "@babel/cli@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.4.4.tgz#5454bb7112f29026a4069d8e6f0e1794e651966c"
-  integrity sha512-XGr5YjQSjgTa6OzQZY57FAJsdeVSAKR/u/KA5exWIz66IKtv/zXtHy+fIZcMry/EgYegwuHE7vzGnrFhjdIAsQ==
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.7.4.tgz#38804334c8db40209f88c69a5c90998e60cca18b"
+  integrity sha512-O7mmzaWdm+VabWQmxuM8hqNrWGGihN83KfhPUzp2lAW4kzIMwBxujXkZbD4fMwKMYY9FXTbDvXsJqU+5XHXi4A==
   dependencies:
-    commander "^2.8.1"
+    commander "^4.0.1"
     convert-source-map "^1.1.0"
     fs-readdir-recursive "^1.1.0"
     glob "^7.0.0"
-    lodash "^4.17.11"
-    mkdirp "^0.5.1"
-    output-file-sync "^2.0.0"
+    lodash "^4.17.13"
+    make-dir "^2.1.0"
     slash "^2.0.0"
     source-map "^0.5.0"
   optionalDependencies:
-    chokidar "^2.0.4"
+    chokidar "^2.1.8"
 
-"@babel/code-frame@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
-  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
   dependencies:
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
-  integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.4.tgz#37e864532200cb6b50ee9a4045f5f817840166ab"
+  integrity sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.4.4"
-    "@babel/helpers" "^7.4.4"
-    "@babel/parser" "^7.4.5"
-    "@babel/template" "^7.4.4"
-    "@babel/traverse" "^7.4.5"
-    "@babel/types" "^7.4.4"
-    convert-source-map "^1.1.0"
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/helpers" "^7.7.4"
+    "@babel/parser" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    convert-source-map "^1.7.0"
     debug "^4.1.0"
     json5 "^2.1.0"
-    lodash "^4.17.11"
+    lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
-  integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
+"@babel/generator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369"
+  integrity sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==
   dependencies:
-    "@babel/types" "^7.4.4"
+    "@babel/types" "^7.7.4"
     jsesc "^2.5.1"
-    lodash "^4.17.11"
+    lodash "^4.17.13"
     source-map "^0.5.0"
-    trim-right "^1.0.1"
 
-"@babel/helper-annotate-as-pure@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
-  integrity sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
+"@babel/helper-annotate-as-pure@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz#bb3faf1e74b74bd547e867e48f551fa6b098b6ce"
+  integrity sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-builder-binary-assignment-operator-visitor@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz#6b69628dfe4087798e0c4ed98e3d4a6b2fbd2f5f"
-  integrity sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz#5f73f2b28580e224b5b9bd03146a4015d6217f5f"
+  integrity sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==
   dependencies:
-    "@babel/helper-explode-assignable-expression" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/helper-explode-assignable-expression" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-builder-react-jsx@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz#a1ac95a5d2b3e88ae5e54846bf462eeb81b318a4"
-  integrity sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==
+"@babel/helper-builder-react-jsx@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.4.tgz#da188d247508b65375b2c30cf59de187be6b0c66"
+  integrity sha512-kvbfHJNN9dg4rkEM4xn1s8d1/h6TYNvajy9L1wx4qLn9HFg0IkTsQi4rfBe92nxrPUFcMsHoMV+8rU7MJb3fCA==
   dependencies:
-    "@babel/types" "^7.3.0"
+    "@babel/types" "^7.7.4"
     esutils "^2.0.0"
 
-"@babel/helper-call-delegate@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz#87c1f8ca19ad552a736a7a27b1c1fcf8b1ff1f43"
-  integrity sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==
+"@babel/helper-call-delegate@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz#621b83e596722b50c0066f9dc37d3232e461b801"
+  integrity sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==
   dependencies:
-    "@babel/helper-hoist-variables" "^7.4.4"
-    "@babel/traverse" "^7.4.4"
-    "@babel/types" "^7.4.4"
+    "@babel/helper-hoist-variables" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-define-map@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz#6969d1f570b46bdc900d1eba8e5d59c48ba2c12a"
-  integrity sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==
+"@babel/helper-create-class-features-plugin@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz#fce60939fd50618610942320a8d951b3b639da2d"
+  integrity sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==
   dependencies:
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/types" "^7.4.4"
-    lodash "^4.17.11"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/helper-member-expression-to-functions" "^7.7.4"
+    "@babel/helper-optimise-call-expression" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
 
-"@babel/helper-explode-assignable-expression@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz#537fa13f6f1674df745b0c00ec8fe4e99681c8f6"
-  integrity sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==
+"@babel/helper-create-regexp-features-plugin@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz#6d5762359fd34f4da1500e4cff9955b5299aaf59"
+  integrity sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==
   dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.6.0"
 
-"@babel/helper-function-name@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
-  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
+"@babel/helper-define-map@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz#2841bf92eb8bd9c906851546fe6b9d45e162f176"
+  integrity sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.0.0"
-    "@babel/template" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    lodash "^4.17.13"
 
-"@babel/helper-get-function-arity@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
-  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+"@babel/helper-explode-assignable-expression@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz#fa700878e008d85dc51ba43e9fb835cddfe05c84"
+  integrity sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-hoist-variables@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz#0298b5f25c8c09c53102d52ac4a98f773eb2850a"
-  integrity sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==
+"@babel/helper-function-name@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz#ab6e041e7135d436d8f0a3eca15de5b67a341a2e"
+  integrity sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==
   dependencies:
-    "@babel/types" "^7.4.4"
+    "@babel/helper-get-function-arity" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-member-expression-to-functions@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f"
-  integrity sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==
+"@babel/helper-get-function-arity@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0"
+  integrity sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-module-imports@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
-  integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
+"@babel/helper-hoist-variables@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz#612384e3d823fdfaaf9fce31550fe5d4db0f3d12"
+  integrity sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-module-transforms@^7.1.0", "@babel/helper-module-transforms@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz#96115ea42a2f139e619e98ed46df6019b94414b8"
-  integrity sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==
+"@babel/helper-member-expression-to-functions@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz#356438e2569df7321a8326644d4b790d2122cb74"
+  integrity sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==
   dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/helper-simple-access" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/template" "^7.4.4"
-    "@babel/types" "^7.4.4"
-    lodash "^4.17.11"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-optimise-call-expression@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
-  integrity sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==
+"@babel/helper-module-imports@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz#e5a92529f8888bf319a6376abfbd1cebc491ad91"
+  integrity sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.7.4"
+
+"@babel/helper-module-transforms@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.7.4.tgz#8d7cdb1e1f8ea3d8c38b067345924ac4f8e0879a"
+  integrity sha512-ehGBu4mXrhs0FxAqN8tWkzF8GSIGAiEumu4ONZ/hD9M88uHcD+Yu2ttKfOCgwzoesJOJrtQh7trI5YPbRtMmnA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.7.4"
+    "@babel/helper-simple-access" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    lodash "^4.17.13"
+
+"@babel/helper-optimise-call-expression@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz#034af31370d2995242aa4df402c3b7794b2dcdf2"
+  integrity sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==
+  dependencies:
+    "@babel/types" "^7.7.4"
 
 "@babel/helper-plugin-utils@^7.0.0":
   version "7.0.0"
@@ -168,496 +186,522 @@
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
 
 "@babel/helper-regex@^7.0.0", "@babel/helper-regex@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.4.4.tgz#a47e02bc91fb259d2e6727c2a30013e3ac13c4a2"
-  integrity sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.5.5.tgz#0aa6824f7100a2e0e89c1527c23936c152cab351"
+  integrity sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.13"
 
-"@babel/helper-remap-async-to-generator@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz#361d80821b6f38da75bd3f0785ece20a88c5fe7f"
-  integrity sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==
+"@babel/helper-remap-async-to-generator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz#c68c2407350d9af0e061ed6726afb4fff16d0234"
+  integrity sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.0.0"
-    "@babel/helper-wrap-function" "^7.1.0"
-    "@babel/template" "^7.1.0"
-    "@babel/traverse" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/helper-annotate-as-pure" "^7.7.4"
+    "@babel/helper-wrap-function" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-replace-supers@^7.1.0", "@babel/helper-replace-supers@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz#aee41783ebe4f2d3ab3ae775e1cc6f1a90cefa27"
-  integrity sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==
+"@babel/helper-replace-supers@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz#3c881a6a6a7571275a72d82e6107126ec9e2cdd2"
+  integrity sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.0.0"
-    "@babel/helper-optimise-call-expression" "^7.0.0"
-    "@babel/traverse" "^7.4.4"
-    "@babel/types" "^7.4.4"
+    "@babel/helper-member-expression-to-functions" "^7.7.4"
+    "@babel/helper-optimise-call-expression" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-simple-access@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
-  integrity sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==
+"@babel/helper-simple-access@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz#a169a0adb1b5f418cfc19f22586b2ebf58a9a294"
+  integrity sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==
   dependencies:
-    "@babel/template" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/template" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-split-export-declaration@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
-  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+"@babel/helper-split-export-declaration@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz#57292af60443c4a3622cf74040ddc28e68336fd8"
+  integrity sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==
   dependencies:
-    "@babel/types" "^7.4.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helper-wrap-function@^7.1.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
-  integrity sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==
+"@babel/helper-wrap-function@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz#37ab7fed5150e22d9d7266e830072c0cdd8baace"
+  integrity sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==
   dependencies:
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/template" "^7.1.0"
-    "@babel/traverse" "^7.1.0"
-    "@babel/types" "^7.2.0"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/helpers@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.4.tgz#868b0ef59c1dd4e78744562d5ce1b59c89f2f2a5"
-  integrity sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==
+"@babel/helpers@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.7.4.tgz#62c215b9e6c712dadc15a9a0dcab76c92a940302"
+  integrity sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==
   dependencies:
-    "@babel/template" "^7.4.4"
-    "@babel/traverse" "^7.4.4"
-    "@babel/types" "^7.4.4"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
 "@babel/highlight@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
-  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
+  integrity sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
-  integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
+"@babel/parser@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.4.tgz#75ab2d7110c2cf2fa949959afb05fa346d2231bb"
+  integrity sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==
 
-"@babel/plugin-proposal-async-generator-functions@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
-  integrity sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==
+"@babel/plugin-proposal-async-generator-functions@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz#0351c5ac0a9e927845fffd5b82af476947b7ce6d"
+  integrity sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-remap-async-to-generator" "^7.1.0"
-    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/helper-remap-async-to-generator" "^7.7.4"
+    "@babel/plugin-syntax-async-generators" "^7.7.4"
 
-"@babel/plugin-proposal-json-strings@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
-  integrity sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==
+"@babel/plugin-proposal-dynamic-import@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz#dde64a7f127691758cbfed6cf70de0fa5879d52d"
+  integrity sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.7.4"
 
-"@babel/plugin-proposal-object-rest-spread@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz#1ef173fcf24b3e2df92a678f027673b55e7e3005"
-  integrity sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==
+"@babel/plugin-proposal-json-strings@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz#7700a6bfda771d8dc81973249eac416c6b4c697d"
+  integrity sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.7.4"
 
-"@babel/plugin-proposal-optional-catch-binding@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz#135d81edb68a081e55e56ec48541ece8065c38f5"
-  integrity sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==
+"@babel/plugin-proposal-object-rest-spread@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz#cc57849894a5c774214178c8ab64f6334ec8af71"
+  integrity sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.7.4"
 
-"@babel/plugin-proposal-unicode-property-regex@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz#501ffd9826c0b91da22690720722ac7cb1ca9c78"
-  integrity sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==
+"@babel/plugin-proposal-optional-catch-binding@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz#ec21e8aeb09ec6711bc0a39ca49520abee1de379"
+  integrity sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-regex" "^7.4.4"
-    regexpu-core "^4.5.4"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.7.4"
 
-"@babel/plugin-syntax-async-generators@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
-  integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
+"@babel/plugin-proposal-unicode-property-regex@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz#7c239ccaf09470dbe1d453d50057460e84517ebb"
+  integrity sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==
   dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-json-strings@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"
-  integrity sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-jsx@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz#0b85a3b4bc7cdf4cc4b8bf236335b907ca22e7c7"
-  integrity sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==
+"@babel/plugin-syntax-async-generators@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz#331aaf310a10c80c44a66b238b6e49132bd3c889"
+  integrity sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-object-rest-spread@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
-  integrity sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
+"@babel/plugin-syntax-dynamic-import@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz#29ca3b4415abfe4a5ec381e903862ad1a54c3aec"
+  integrity sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-optional-catch-binding@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
-  integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+"@babel/plugin-syntax-json-strings@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz#86e63f7d2e22f9e27129ac4e83ea989a382e86cc"
+  integrity sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-typescript@^7.2.0":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz#a7cc3f66119a9f7ebe2de5383cce193473d65991"
-  integrity sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==
+"@babel/plugin-syntax-jsx@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz#dab2b56a36fb6c3c222a1fbc71f7bf97f327a9ec"
+  integrity sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-arrow-functions@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
-  integrity sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==
+"@babel/plugin-syntax-object-rest-spread@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz#47cf220d19d6d0d7b154304701f468fc1cc6ff46"
+  integrity sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-async-to-generator@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz#a3f1d01f2f21cadab20b33a82133116f14fb5894"
-  integrity sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-remap-async-to-generator" "^7.1.0"
-
-"@babel/plugin-transform-block-scoped-functions@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz#5d3cc11e8d5ddd752aa64c9148d0db6cb79fd190"
-  integrity sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==
+"@babel/plugin-syntax-optional-catch-binding@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz#a3e38f59f4b6233867b4a92dcb0ee05b2c334aa6"
+  integrity sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-block-scoping@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz#c13279fabf6b916661531841a23c4b7dae29646d"
-  integrity sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==
+"@babel/plugin-syntax-top-level-await@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz#bd7d8fa7b9fee793a36e4027fd6dd1aa32f946da"
+  integrity sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    lodash "^4.17.11"
 
-"@babel/plugin-transform-classes@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz#0ce4094cdafd709721076d3b9c38ad31ca715eb6"
-  integrity sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==
+"@babel/plugin-syntax-typescript@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.7.4.tgz#5d037ffa10f3b25a16f32570ebbe7a8c2efa304b"
+  integrity sha512-77blgY18Hud4NM1ggTA8xVT/dBENQf17OpiToSa2jSmEY3fWXD2jwrdVlO4kq5yzUTeF15WSQ6b4fByNvJcjpQ==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.0.0"
-    "@babel/helper-define-map" "^7.4.4"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-optimise-call-expression" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.4.4"
-    "@babel/helper-split-export-declaration" "^7.4.4"
+
+"@babel/plugin-transform-arrow-functions@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz#76309bd578addd8aee3b379d809c802305a98a12"
+  integrity sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-async-to-generator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz#694cbeae6d613a34ef0292713fa42fb45c4470ba"
+  integrity sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.7.4"
+
+"@babel/plugin-transform-block-scoped-functions@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz#d0d9d5c269c78eaea76227ace214b8d01e4d837b"
+  integrity sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-block-scoping@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz#200aad0dcd6bb80372f94d9e628ea062c58bf224"
+  integrity sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.13"
+
+"@babel/plugin-transform-classes@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz#c92c14be0a1399e15df72667067a8f510c9400ec"
+  integrity sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.7.4"
+    "@babel/helper-define-map" "^7.7.4"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/helper-optimise-call-expression" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da"
-  integrity sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==
+"@babel/plugin-transform-computed-properties@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz#e856c1628d3238ffe12d668eb42559f79a81910d"
+  integrity sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-destructuring@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz#9d964717829cc9e4b601fc82a26a71a4d8faf20f"
-  integrity sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==
+"@babel/plugin-transform-destructuring@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz#2b713729e5054a1135097b6a67da1b6fe8789267"
+  integrity sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-dotall-regex@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz#361a148bc951444312c69446d76ed1ea8e4450c3"
-  integrity sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==
+"@babel/plugin-transform-dotall-regex@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz#f7ccda61118c5b7a2599a72d5e3210884a021e96"
+  integrity sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-regex" "^7.4.4"
-    regexpu-core "^4.5.4"
-
-"@babel/plugin-transform-duplicate-keys@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz#d952c4930f312a4dbfff18f0b2914e60c35530b3"
-  integrity sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==
-  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-exponentiation-operator@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz#a63868289e5b4007f7054d46491af51435766008"
-  integrity sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==
-  dependencies:
-    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.1.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-transform-for-of@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz#0267fc735e24c808ba173866c6c4d1440fc3c556"
-  integrity sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==
+"@babel/plugin-transform-duplicate-keys@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz#3d21731a42e3f598a73835299dd0169c3b90ac91"
+  integrity sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-function-name@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz#e1436116abb0610c2259094848754ac5230922ad"
-  integrity sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==
+"@babel/plugin-transform-exponentiation-operator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz#dd30c0191e3a1ba19bcc7e389bdfddc0729d5db9"
+  integrity sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==
   dependencies:
-    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-literals@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz#690353e81f9267dad4fd8cfd77eafa86aba53ea1"
-  integrity sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-transform-member-expression-literals@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz#fa10aa5c58a2cb6afcf2c9ffa8cb4d8b3d489a2d"
-  integrity sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==
+"@babel/plugin-transform-for-of@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz#248800e3a5e507b1f103d8b4ca998e77c63932bc"
+  integrity sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-modules-amd@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz#82a9bce45b95441f617a24011dc89d12da7f4ee6"
-  integrity sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==
+"@babel/plugin-transform-function-name@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz#75a6d3303d50db638ff8b5385d12451c865025b1"
+  integrity sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==
   dependencies:
-    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-function-name" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-modules-commonjs@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz#0bef4713d30f1d78c2e59b3d6db40e60192cac1e"
-  integrity sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==
-  dependencies:
-    "@babel/helper-module-transforms" "^7.4.4"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-simple-access" "^7.1.0"
-
-"@babel/plugin-transform-modules-systemjs@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz#dc83c5665b07d6c2a7b224c00ac63659ea36a405"
-  integrity sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==
-  dependencies:
-    "@babel/helper-hoist-variables" "^7.4.4"
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-transform-modules-umd@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz#7678ce75169f0877b8eb2235538c074268dd01ae"
-  integrity sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==
-  dependencies:
-    "@babel/helper-module-transforms" "^7.1.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-transform-named-capturing-groups-regex@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz#9d269fd28a370258199b4294736813a60bbdd106"
-  integrity sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==
-  dependencies:
-    regexp-tree "^0.1.6"
-
-"@babel/plugin-transform-new-target@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz#18d120438b0cc9ee95a47f2c72bc9768fbed60a5"
-  integrity sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==
+"@babel/plugin-transform-literals@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz#27fe87d2b5017a2a5a34d1c41a6b9f6a6262643e"
+  integrity sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-object-super@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598"
-  integrity sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.1.0"
-
-"@babel/plugin-transform-parameters@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz#7556cf03f318bd2719fe4c922d2d808be5571e16"
-  integrity sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==
-  dependencies:
-    "@babel/helper-call-delegate" "^7.4.4"
-    "@babel/helper-get-function-arity" "^7.0.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-transform-property-literals@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz#03e33f653f5b25c4eb572c98b9485055b389e905"
-  integrity sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==
+"@babel/plugin-transform-member-expression-literals@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz#aee127f2f3339fc34ce5e3055d7ffbf7aa26f19a"
+  integrity sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-react-display-name@^7.0.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz#ebfaed87834ce8dc4279609a4f0c324c156e3eb0"
-  integrity sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==
+"@babel/plugin-transform-modules-amd@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.4.tgz#276b3845ca2b228f2995e453adc2e6f54d72fb71"
+  integrity sha512-/542/5LNA18YDtg1F+QHvvUSlxdvjZoD/aldQwkq+E3WCkbEjNSN9zdrOXaSlfg3IfGi22ijzecklF/A7kVZFQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz#bee4386e550446343dd52a571eda47851ff857a3"
+  integrity sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.7.4"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz#cd98152339d3e763dfe838b7d4273edaf520bb30"
+  integrity sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-umd@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz#1027c355a118de0aae9fee00ad7813c584d9061f"
+  integrity sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-named-capturing-groups-regex@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz#fb3bcc4ee4198e7385805007373d6b6f42c98220"
+  integrity sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.7.4"
+
+"@babel/plugin-transform-new-target@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz#4a0753d2d60639437be07b592a9e58ee00720167"
+  integrity sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-react-jsx-self@^7.0.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz#461e21ad9478f1031dd5e276108d027f1b5240ba"
-  integrity sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==
+"@babel/plugin-transform-object-super@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz#48488937a2d586c0148451bf51af9d7dda567262"
+  integrity sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-jsx" "^7.2.0"
+    "@babel/helper-replace-supers" "^7.7.4"
 
-"@babel/plugin-transform-react-jsx-source@^7.0.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz#20c8c60f0140f5dd3cd63418d452801cf3f7180f"
-  integrity sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==
+"@babel/plugin-transform-parameters@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz#da4555c97f39b51ac089d31c7380f03bca4075ce"
+  integrity sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==
+  dependencies:
+    "@babel/helper-call-delegate" "^7.7.4"
+    "@babel/helper-get-function-arity" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-property-literals@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz#2388d6505ef89b266103f450f9167e6bd73f98c2"
+  integrity sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-react-jsx@^7.0.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz#f2cab99026631c767e2745a5368b331cfe8f5290"
-  integrity sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==
+"@babel/plugin-transform-react-display-name@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.7.4.tgz#9f2b80b14ebc97eef4a9b29b612c58ed9c0d10dd"
+  integrity sha512-sBbIvqYkthai0X0vkD2xsAwluBp+LtNHH+/V4a5ydifmTtb8KOVOlrMIk/MYmIc4uTYDnjZUHQildYNo36SRJw==
   dependencies:
-    "@babel/helper-builder-react-jsx" "^7.3.0"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-regenerator@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz#629dc82512c55cee01341fb27bdfcb210354680f"
-  integrity sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==
+"@babel/plugin-transform-react-jsx-self@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.7.4.tgz#81b8fbfd14b2215e8f1c2c3adfba266127b0231c"
+  integrity sha512-PWYjSfqrO273mc1pKCRTIJXyqfc9vWYBax88yIhQb+bpw3XChVC7VWS4VwRVs63wFHKxizvGSd00XEr+YB9Q2A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.7.4"
+
+"@babel/plugin-transform-react-jsx-source@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.7.4.tgz#8994b1bf6014b133f5a46d3b7d1ee5f5e3e72c10"
+  integrity sha512-5ZU9FnPhqtHsOXxutRtXZAzoEJwDaP32QcobbMP1/qt7NYcsCNK8XgzJcJfoEr/ZnzVvUNInNjIW22Z6I8p9mg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.7.4"
+
+"@babel/plugin-transform-react-jsx@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.4.tgz#d91205717fae4e2f84d020cd3057ec02a10f11da"
+  integrity sha512-LixU4BS95ZTEAZdPaIuyg/k8FiiqN9laQ0dMHB4MlpydHY53uQdWCUrwjLr5o6ilS6fAgZey4Q14XBjl5tL6xw==
+  dependencies:
+    "@babel/helper-builder-react-jsx" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.7.4"
+
+"@babel/plugin-transform-regenerator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.4.tgz#d18eac0312a70152d7d914cbed2dc3999601cfc0"
+  integrity sha512-e7MWl5UJvmPEwFJTwkBlPmqixCtr9yAASBqff4ggXTNicZiwbF8Eefzm6NVgfiBp7JdAGItecnctKTgH44q2Jw==
   dependencies:
     regenerator-transform "^0.14.0"
 
-"@babel/plugin-transform-reserved-words@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz#4792af87c998a49367597d07fedf02636d2e1634"
-  integrity sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==
+"@babel/plugin-transform-reserved-words@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz#6a7cf123ad175bb5c69aec8f6f0770387ed3f1eb"
+  integrity sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-shorthand-properties@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
-  integrity sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==
+"@babel/plugin-transform-shorthand-properties@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz#74a0a9b2f6d67a684c6fbfd5f0458eb7ba99891e"
+  integrity sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-spread@^7.2.0":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406"
-  integrity sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==
+"@babel/plugin-transform-spread@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz#aa673b356fe6b7e70d69b6e33a17fef641008578"
+  integrity sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-sticky-regex@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz#a1e454b5995560a9c1e0d537dfc15061fd2687e1"
-  integrity sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==
+"@babel/plugin-transform-sticky-regex@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz#ffb68c05090c30732076b1285dc1401b404a123c"
+  integrity sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
 
-"@babel/plugin-transform-template-literals@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz#9d28fea7bbce637fb7612a0750989d8321d4bcb0"
-  integrity sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
+"@babel/plugin-transform-template-literals@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz#1eb6411736dd3fe87dbd20cc6668e5121c17d604"
+  integrity sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-annotate-as-pure" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-typeof-symbol@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
-  integrity sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==
+"@babel/plugin-transform-typeof-symbol@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz#3174626214f2d6de322882e498a38e8371b2140e"
+  integrity sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-typescript@^7.3.2":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz#ab3351ba35307b79981993536c93ff8be050ba28"
-  integrity sha512-RPB/YeGr4ZrFKNwfuQRlMf2lxoCUaU01MTw39/OFE/RiL8HDjtn68BwEPft1P7JN4akyEmjGWAMNldOV7o9V2g==
+"@babel/plugin-transform-typescript@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.4.tgz#2974fd05f4e85c695acaf497f432342de9fc0636"
+  integrity sha512-X8e3tcPEKnwwPVG+vP/vSqEShkwODOEeyQGod82qrIuidwIrfnsGn11qPM1jBLF4MqguTXXYzm58d0dY+/wdpg==
   dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-typescript" "^7.2.0"
+    "@babel/plugin-syntax-typescript" "^7.7.4"
 
-"@babel/plugin-transform-unicode-regex@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
-  integrity sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
+"@babel/plugin-transform-unicode-regex@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz#a3c0f65b117c4c81c5b6484f2a5e7b95346b83ae"
+  integrity sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==
   dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-regex" "^7.4.4"
-    regexpu-core "^4.5.4"
 
 "@babel/preset-env@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.5.tgz#2fad7f62983d5af563b5f3139242755884998a58"
-  integrity sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.7.4.tgz#ccaf309ae8d1ee2409c85a4e2b5e280ceee830f8"
+  integrity sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==
   dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-module-imports" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
-    "@babel/plugin-proposal-json-strings" "^7.2.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.4.4"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
-    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
-    "@babel/plugin-syntax-async-generators" "^7.2.0"
-    "@babel/plugin-syntax-json-strings" "^7.2.0"
-    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
-    "@babel/plugin-transform-arrow-functions" "^7.2.0"
-    "@babel/plugin-transform-async-to-generator" "^7.4.4"
-    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
-    "@babel/plugin-transform-block-scoping" "^7.4.4"
-    "@babel/plugin-transform-classes" "^7.4.4"
-    "@babel/plugin-transform-computed-properties" "^7.2.0"
-    "@babel/plugin-transform-destructuring" "^7.4.4"
-    "@babel/plugin-transform-dotall-regex" "^7.4.4"
-    "@babel/plugin-transform-duplicate-keys" "^7.2.0"
-    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
-    "@babel/plugin-transform-for-of" "^7.4.4"
-    "@babel/plugin-transform-function-name" "^7.4.4"
-    "@babel/plugin-transform-literals" "^7.2.0"
-    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
-    "@babel/plugin-transform-modules-amd" "^7.2.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
-    "@babel/plugin-transform-modules-systemjs" "^7.4.4"
-    "@babel/plugin-transform-modules-umd" "^7.2.0"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.5"
-    "@babel/plugin-transform-new-target" "^7.4.4"
-    "@babel/plugin-transform-object-super" "^7.2.0"
-    "@babel/plugin-transform-parameters" "^7.4.4"
-    "@babel/plugin-transform-property-literals" "^7.2.0"
-    "@babel/plugin-transform-regenerator" "^7.4.5"
-    "@babel/plugin-transform-reserved-words" "^7.2.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
-    "@babel/plugin-transform-spread" "^7.2.0"
-    "@babel/plugin-transform-sticky-regex" "^7.2.0"
-    "@babel/plugin-transform-template-literals" "^7.4.4"
-    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
-    "@babel/plugin-transform-unicode-regex" "^7.4.4"
-    "@babel/types" "^7.4.4"
+    "@babel/plugin-proposal-async-generator-functions" "^7.7.4"
+    "@babel/plugin-proposal-dynamic-import" "^7.7.4"
+    "@babel/plugin-proposal-json-strings" "^7.7.4"
+    "@babel/plugin-proposal-object-rest-spread" "^7.7.4"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.7.4"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.7.4"
+    "@babel/plugin-syntax-async-generators" "^7.7.4"
+    "@babel/plugin-syntax-dynamic-import" "^7.7.4"
+    "@babel/plugin-syntax-json-strings" "^7.7.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.7.4"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.7.4"
+    "@babel/plugin-syntax-top-level-await" "^7.7.4"
+    "@babel/plugin-transform-arrow-functions" "^7.7.4"
+    "@babel/plugin-transform-async-to-generator" "^7.7.4"
+    "@babel/plugin-transform-block-scoped-functions" "^7.7.4"
+    "@babel/plugin-transform-block-scoping" "^7.7.4"
+    "@babel/plugin-transform-classes" "^7.7.4"
+    "@babel/plugin-transform-computed-properties" "^7.7.4"
+    "@babel/plugin-transform-destructuring" "^7.7.4"
+    "@babel/plugin-transform-dotall-regex" "^7.7.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.7.4"
+    "@babel/plugin-transform-exponentiation-operator" "^7.7.4"
+    "@babel/plugin-transform-for-of" "^7.7.4"
+    "@babel/plugin-transform-function-name" "^7.7.4"
+    "@babel/plugin-transform-literals" "^7.7.4"
+    "@babel/plugin-transform-member-expression-literals" "^7.7.4"
+    "@babel/plugin-transform-modules-amd" "^7.7.4"
+    "@babel/plugin-transform-modules-commonjs" "^7.7.4"
+    "@babel/plugin-transform-modules-systemjs" "^7.7.4"
+    "@babel/plugin-transform-modules-umd" "^7.7.4"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.7.4"
+    "@babel/plugin-transform-new-target" "^7.7.4"
+    "@babel/plugin-transform-object-super" "^7.7.4"
+    "@babel/plugin-transform-parameters" "^7.7.4"
+    "@babel/plugin-transform-property-literals" "^7.7.4"
+    "@babel/plugin-transform-regenerator" "^7.7.4"
+    "@babel/plugin-transform-reserved-words" "^7.7.4"
+    "@babel/plugin-transform-shorthand-properties" "^7.7.4"
+    "@babel/plugin-transform-spread" "^7.7.4"
+    "@babel/plugin-transform-sticky-regex" "^7.7.4"
+    "@babel/plugin-transform-template-literals" "^7.7.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.7.4"
+    "@babel/plugin-transform-unicode-regex" "^7.7.4"
+    "@babel/types" "^7.7.4"
     browserslist "^4.6.0"
     core-js-compat "^3.1.1"
     invariant "^2.2.2"
@@ -665,90 +709,90 @@
     semver "^5.5.0"
 
 "@babel/preset-react@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"
-  integrity sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.7.4.tgz#3fe2ea698d8fb536d8e7881a592c3c1ee8bf5707"
+  integrity sha512-j+vZtg0/8pQr1H8wKoaJyGL2IEk3rG/GIvua7Sec7meXVIvGycihlGMx5xcU00kqCJbwzHs18xTu3YfREOqQ+g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+    "@babel/plugin-transform-react-display-name" "^7.7.4"
+    "@babel/plugin-transform-react-jsx" "^7.7.4"
+    "@babel/plugin-transform-react-jsx-self" "^7.7.4"
+    "@babel/plugin-transform-react-jsx-source" "^7.7.4"
 
 "@babel/preset-typescript@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz#88669911053fa16b2b276ea2ede2ca603b3f307a"
-  integrity sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.7.4.tgz#780059a78e6fa7f7a4c87f027292a86b31ce080a"
+  integrity sha512-rqrjxfdiHPsnuPur0jKrIIGQCIgoTWMTjlbWE69G4QJ6TIOVnnRnIJhUxNTL/VwDmEAVX08Tq3B1nirer5341w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.3.2"
+    "@babel/plugin-transform-typescript" "^7.7.4"
 
-"@babel/template@^7.1.0", "@babel/template@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
-  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+"@babel/template@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
+  integrity sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.4.4"
-    "@babel/types" "^7.4.4"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.4.5":
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
-  integrity sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==
+"@babel/traverse@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.4.tgz#9c1e7c60fb679fe4fcfaa42500833333c2058558"
+  integrity sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.4.4"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.4.5"
-    "@babel/types" "^7.4.4"
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.11"
+    lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
-  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
+"@babel/types@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
+  integrity sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==
   dependencies:
     esutils "^2.0.2"
-    lodash "^4.17.11"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@fimbul/bifrost@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.15.0.tgz#f3a48dee3046681e926c1f970f0b1a67e29e088e"
-  integrity sha512-sHTwnwA9YhxcVEJkBlfKH1KLmGQGnNYPxk+09w5NnkXelYiiP8a5f351weYfxG0CUPLt1Fgkha20Y/9+jhjn/Q==
+"@fimbul/bifrost@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.21.0.tgz#d0fafa25938fda475657a6a1e407a21bbe02c74e"
+  integrity sha512-ou8VU+nTmOW1jeg+FT+sn+an/M0Xb9G16RucrfhjXGWv1Q97kCoM5CG9Qj7GYOSdu7km72k7nY83Eyr53Bkakg==
   dependencies:
-    "@fimbul/ymir" "^0.15.0"
+    "@fimbul/ymir" "^0.21.0"
     get-caller-file "^2.0.0"
     tslib "^1.8.1"
-    tsutils "^3.1.0"
+    tsutils "^3.5.0"
 
-"@fimbul/ymir@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@fimbul/ymir/-/ymir-0.15.0.tgz#944c881b14fadf7b43d1ae00b445e42261bb407f"
-  integrity sha512-Ow0TfxxQ65vIktHcZyXHeDsGKuzJ9Vt6y77R/aOrXQXLMdYHG+XdbiUWzQbtaGOmNzYVkQfINiFnIdvn5Bn24g==
+"@fimbul/ymir@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@fimbul/ymir/-/ymir-0.21.0.tgz#8525726787aceeafd4e199472c0d795160b5d4a1"
+  integrity sha512-T/y7WqPsm4n3zhT08EpB5sfdm2Kvw3gurAxr2Lr5dQeLi8ZsMlNT/Jby+ZmuuAAd1PnXYzKp+2SXgIkQIIMCUg==
   dependencies:
     inversify "^5.0.0"
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
 "@types/lodash@^4.14.118":
-  version "4.14.118"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
-  integrity sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
 "@types/prop-types@*":
-  version "15.5.6"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
-  integrity sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
 "@types/react@^16.7.7":
-  version "16.7.7"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.7.tgz#1e5e23e7dd922968ed4b484cdec00a5402c9f31b"
-  integrity sha512-dJiq7CKxD1XJ/GqmbnsQisFnzG4z5lntKBw9X9qeSrguxFbrrhGa8cK9s0ONBp8wL1EfGfofEDVhjen26U46pw==
+  version "16.9.13"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.13.tgz#b3ea5dd443f4a680599e2abba8cc66f5e1ce0059"
+  integrity sha512-LikzRslbiufJYHyzbHSW0GrAiff8QYLMBFeZmSxzCYGXKxi8m/1PHX+rsVOwhr7mJNq+VIu2Dhf7U6mjFERK6w==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -761,15 +805,12 @@ abbrev@1:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -800,8 +841,9 @@ are-we-there-yet@~1.1.2:
     readable-stream "^2.0.6"
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -825,10 +867,6 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -844,17 +882,17 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-babel-code-frame@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
+babel-plugin-dynamic-import-node@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
+  integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
   dependencies:
-    chalk "^1.1.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
+    object.assign "^4.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base@^0.11.1:
   version "0.11.2"
@@ -875,8 +913,9 @@ binary-extensions@^1.0.0:
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -897,18 +936,19 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-browserslist@^4.6.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
-  integrity sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==
+browserslist@^4.6.0, browserslist@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.3.tgz#02341f162b6bcc1e1028e30624815d4924442dc3"
+  integrity sha512-jWvmhqYpx+9EZm/FxcZSbUZyDEvDTLDi3nSAKbzEkyWvtI0mNSmUosey+5awDW1RUlrgXbQb5A6qY1xQH9U6MQ==
   dependencies:
-    caniuse-lite "^1.0.30000974"
-    electron-to-chromium "^1.3.150"
-    node-releases "^1.1.23"
+    caniuse-lite "^1.0.30001010"
+    electron-to-chromium "^1.3.306"
+    node-releases "^1.1.40"
 
 builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -925,22 +965,12 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-caniuse-lite@^1.0.30000974:
-  version "1.0.30000974"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
-  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
+caniuse-lite@^1.0.30001010:
+  version "1.0.30001012"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001012.tgz#653ec635e815b9e0fb801890923b0c2079eb34ec"
+  integrity sha512-7RR4Uh04t9K1uYRWzOJmzplgEOAXbfK72oVNokCdMzA67trrhPzy93ahKk1AWHiA0c58tD2P+NHqxrA8FZ+Trg==
 
-chalk@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -949,19 +979,10 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.3.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chokidar@^2.0.4:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
-  integrity sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==
+chokidar@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
+  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"
@@ -978,9 +999,9 @@ chokidar@^2.0.4:
     fsevents "^1.2.7"
 
 chownr@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
-  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
+  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -1006,24 +1027,26 @@ collection-visit@^1.0.0:
     object-visit "^1.0.0"
 
 color-convert@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
-    color-name "^1.1.1"
+    color-name "1.1.3"
 
-color-name@^1.1.1:
+color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 commander@^2.12.1:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^2.8.1:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+commander@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.0.1.tgz#b67622721785993182e807f4883633e6401ba53c"
+  integrity sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -1033,16 +1056,17 @@ component-emitter@^1.2.1:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-convert-source-map@^1.1.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
-  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+convert-source-map@^1.1.0, convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
 
@@ -1052,40 +1076,22 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.1.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.1.3.tgz#0cc3ba4c7f62928c2837e1cffbe8dc78b4f1ae14"
-  integrity sha512-EP018pVhgwsKHz3YoN1hTq49aRe+h017Kjz0NQz3nXV0cCRMvH3fLQl+vEPGr4r4J5sk4sU3tUC7U1aqTCeJeA==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.4.2.tgz#652fa7c54652b7f6586a893e37001df55ea2ac37"
+  integrity sha512-W0Aj+LM3EAxxjD0Kp2o4be8UlnxIZHNupBv2znqrheR4aY2nOn91794k/xoSp+SxqqriiZpTsSwBtZr60cbkwQ==
   dependencies:
-    browserslist "^4.6.0"
-    core-js-pure "3.1.3"
-    semver "^6.1.0"
-
-core-js-pure@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.3.tgz#4c90752d5b9471f641514f3728f51c1e0783d0b5"
-  integrity sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==
-
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+    browserslist "^4.7.3"
+    semver "^6.3.0"
 
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-create-react-class@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 csstype@^2.2.0:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
-  integrity sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
+  integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -1117,6 +1123,13 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -1150,10 +1163,10 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-diff@^3.2.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 doctrine@0.7.2:
   version "0.7.2"
@@ -1163,24 +1176,20 @@ doctrine@0.7.2:
     esutils "^1.1.6"
     isarray "0.0.1"
 
-electron-to-chromium@^1.3.150:
-  version "1.3.157"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.157.tgz#6211d69e8c4ee18df8c84e74e8644bcafc09486c"
-  integrity sha512-vxGi3lOGqlupuogZxJOMfu+Q1vaOlG6XbsblWw8XnUZSr/ptbt3D6jhHT5LJPZuFUpKhbEo1u4QipivSory1Kg==
+electron-to-chromium@^1.3.306:
+  version "1.3.314"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.314.tgz#c186a499ed2c9057bce9eb8dca294d6d5450facc"
+  integrity sha512-IKDR/xCxKFhPts7h+VaSXS02Z1mznP3fli1BbXWXeN89i2gCzKraU8qLpEid8YzKcmZdZD3Mly3cn5/lY9xsBQ==
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
-
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esutils@^1.1.6:
   version "1.1.6"
@@ -1188,8 +1197,9 @@ esutils@^1.1.6:
   integrity sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=
 
 esutils@^2.0.0, esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -1233,18 +1243,6 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-fbjs@^0.8.9:
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -1268,11 +1266,11 @@ fragment-cache@^0.2.1:
     map-cache "^0.2.2"
 
 fs-minipass@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
-  integrity sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
   dependencies:
-    minipass "^2.2.1"
+    minipass "^2.6.0"
 
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
@@ -1282,6 +1280,7 @@ fs-readdir-recursive@^1.1.0:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.7:
   version "1.2.9"
@@ -1290,6 +1289,11 @@ fsevents@^1.2.7:
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1306,9 +1310,9 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 get-caller-file@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.0.tgz#1e119be08623cdb28fb6b2873e671a758aa2b6eb"
-  integrity sha512-cF41L/f/7nXpSwMMHMY0FIurpTPZq/eHwJdeh2+0kKYhL9eD7RqsgMujd3qdqvWdjGIHjwvd/iEMTNECl2EhzA==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1323,22 +1327,10 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.1:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1353,20 +1345,19 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 graceful-fs@^4.1.11:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  dependencies:
-    ansi-regex "^2.0.0"
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-symbols@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1411,27 +1402,25 @@ iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@~0.4.13:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
-
 ignore-walk@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
-  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
+  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
   dependencies:
     minimatch "^3.0.4"
 
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
 
 inherits@2, inherits@^2.0.3, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@~1.3.0:
   version "1.3.5"
@@ -1558,21 +1547,12 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
-is-plain-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
-
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
-
-is-stream@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -1601,31 +1581,20 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
-
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
-js-tokens@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.7.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1641,9 +1610,9 @@ jsesc@~0.5.0:
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
 json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
-  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
+  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -1671,21 +1640,25 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-lodash@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-lodash@~4:
+lodash@^4.17.13, lodash@~4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
-    js-tokens "^3.0.0"
+    js-tokens "^3.0.0 || ^4.0.0"
+
+make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -1721,6 +1694,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -1734,25 +1708,25 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minipass@^2.2.1, minipass@^2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
-  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
 minizlib@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
-  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
-    minipass "^2.2.1"
+    minipass "^2.9.0"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
-  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -1805,13 +1779,6 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-node-fetch@^1.0.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
 node-pre-gyp@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
@@ -1828,12 +1795,12 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.23:
-  version "1.1.23"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
-  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
+node-releases@^1.1.40:
+  version "1.1.41"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.41.tgz#57674a82a37f812d18e3b26118aefaf53a00afed"
+  integrity sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==
   dependencies:
-    semver "^5.3.0"
+    semver "^6.3.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -1861,9 +1828,9 @@ npm-bundled@^1.0.1:
   integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
 
 npm-packlist@^1.1.6:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
-  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.6.tgz#53ba3ed11f8523079f1457376dd379ee4ea42ff4"
+  integrity sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -1886,6 +1853,7 @@ number-is-nan@^1.0.0:
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -1896,12 +1864,27 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.11, object-keys@^1.0.12:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -1913,6 +1896,7 @@ object.pick@^1.3.0:
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
@@ -1934,15 +1918,6 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-output-file-sync@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.1.tgz#f53118282f5f553c2799541792b723a4c71430c0"
-  integrity sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==
-  dependencies:
-    graceful-fs "^4.1.11"
-    is-plain-obj "^1.1.0"
-    mkdirp "^0.5.1"
-
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -1956,10 +1931,17 @@ path-dirname@^1.0.0:
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -1972,22 +1954,18 @@ private@^0.1.6:
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
 
 process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
-    asap "~2.0.3"
-
-prop-types@^15.5.10:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 rc@^1.2.7:
   version "1.2.8"
@@ -1999,15 +1977,19 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-is@^16.8.1:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
 react@*:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
+  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 readable-stream@^2.0.2, readable-stream@^2.0.6:
   version "2.3.6"
@@ -2032,11 +2014,11 @@ readdirp@^2.2.1:
     readable-stream "^2.0.2"
 
 reflect-metadata@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.12.tgz#311bf0c6b63cd782f228a81abe146a2bfa9c56f2"
-  integrity sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
-regenerate-unicode-properties@^8.0.2:
+regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
   integrity sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==
@@ -2049,9 +2031,9 @@ regenerate@^1.4.0:
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
 regenerator-transform@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.0.tgz#2ca9aaf7a2c239dd32e4761218425b8c7a86ecaf"
-  integrity sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.1.tgz#3b2fce4e1ab7732c08f665dfdb314749c7ddd2fb"
+  integrity sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==
   dependencies:
     private "^0.1.6"
 
@@ -2063,27 +2045,22 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexp-tree@^0.1.6:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.10.tgz#d837816a039c7af8a8d64d7a7c3cf6a1d93450bc"
-  integrity sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ==
-
-regexpu-core@^4.5.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.4.tgz#080d9d02289aa87fe1667a4f5136bc98a6aebaae"
-  integrity sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==
+regexpu-core@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
+  integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
   dependencies:
     regenerate "^1.4.0"
-    regenerate-unicode-properties "^8.0.2"
+    regenerate-unicode-properties "^8.1.0"
     regjsgen "^0.5.0"
     regjsparser "^0.6.0"
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.1.0"
 
 regjsgen@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.0.tgz#a7634dc08f89209c2049adda3525711fb97265dd"
-  integrity sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.1.tgz#48f0bf1a5ea205196929c0d9798b42d1ed98443c"
+  integrity sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==
 
 regjsparser@^0.6.0:
   version "0.6.0"
@@ -2113,11 +2090,11 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.3.2:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
-  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.2.tgz#08b12496d9aa8659c75f534a8f05f0d892fff594"
+  integrity sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==
   dependencies:
-    path-parse "^1.0.5"
+    path-parse "^1.0.6"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -2125,13 +2102,18 @@ ret@~0.1.10:
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 rimraf@^2.6.1:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
-safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.1.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -2153,48 +2135,30 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-semver@^5.3.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^5.4.1, semver@^5.5.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
-
-semver@^6.1.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
-  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+set-value@^2.0.0, set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 signal-exit@^3.0.0:
   version "3.0.2"
@@ -2267,6 +2231,7 @@ split-string@^3.0.1, split-string@^3.0.2:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -2303,6 +2268,7 @@ string_decoder@~1.1.1:
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
 
@@ -2318,10 +2284,6 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -2330,13 +2292,13 @@ supports-color@^5.3.0:
     has-flag "^3.0.0"
 
 tar@^4:
-  version "4.4.10"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
-  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.3.5"
+    minipass "^2.8.6"
     minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
@@ -2372,36 +2334,31 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-trim-right@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
-
 tslib@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
 tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslint-config-airbnb@^5.11.1:
-  version "5.11.1"
-  resolved "https://registry.yarnpkg.com/tslint-config-airbnb/-/tslint-config-airbnb-5.11.1.tgz#51a27fbb8bf24c144d064a274a71da47e7ece617"
-  integrity sha512-hkaittm2607vVMe8eotANGN1CimD5tor7uoY3ypg2VTtEcDB/KGWYbJOz58t8LI4cWSyWtgqYQ5F0HwKxxhlkQ==
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/tslint-config-airbnb/-/tslint-config-airbnb-5.11.2.tgz#2f3d239fa3923be8e7a4372217a7ed552671528f"
+  integrity sha512-mUpHPTeeCFx8XARGG/kzYP4dPSOgoCqNiYbGHh09qTH8q+Y1ghsOgaeZKYYQT7IyxMos523z/QBaiv2zKNBcow==
   dependencies:
     tslint-consistent-codestyle "^1.14.1"
     tslint-eslint-rules "^5.4.0"
     tslint-microsoft-contrib "~5.2.1"
 
 tslint-consistent-codestyle@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.14.1.tgz#8555f1b05ccbf093166a73347f41eb101731a522"
-  integrity sha512-UxGRX2fF5LpZtqYpuPFaIva+2D7ASX3pTVw41yis6Hmw7PPA3cBnFEX1jqRsnyxGrca6mHxz7xDnwCHtOjWJMQ==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.16.0.tgz#52348ea899a7e025b37cc6545751c6a566a19077"
+  integrity sha512-ebR/xHyMEuU36hGNOgCfjGBNYxBPixf0yU1Yoo6s3BrpBRFccjPOmIVaVvQsWAUAMdmfzHOCihVkcaMfimqvHw==
   dependencies:
-    "@fimbul/bifrost" "^0.15.0"
+    "@fimbul/bifrost" "^0.21.0"
     tslib "^1.7.1"
     tsutils "^2.29.0"
 
@@ -2422,29 +2379,23 @@ tslint-microsoft-contrib@~5.2.1:
     tsutils "^2.27.2 <2.29.0"
 
 tslint@^5.11.0:
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
-  integrity sha1-mPMMAurjzecAYgHkwzywi0hYHu0=
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
+  integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
   dependencies:
-    babel-code-frame "^6.22.0"
+    "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"
     chalk "^2.3.0"
     commander "^2.12.1"
-    diff "^3.2.0"
+    diff "^4.0.1"
     glob "^7.1.1"
-    js-yaml "^3.7.0"
+    js-yaml "^3.13.1"
     minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.27.2"
-
-tsutils@^2.27.2, tsutils@^2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  dependencies:
-    tslib "^1.8.1"
+    tsutils "^2.29.0"
 
 "tsutils@^2.27.2 <2.29.0":
   version "2.28.0"
@@ -2453,21 +2404,24 @@ tsutils@^2.27.2, tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-tsutils@^3.0.0, tsutils@^3.1.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.5.1.tgz#2219e5f0ad728aef94bd6634a5b4d8ce6b2e2eea"
-  integrity sha512-g9kwRQRpVDhjS3qfrDsnYv7QkBtsNRm1Ln5539hq9Y2ysndnlaWf8+3zTdaa1YB5ko7dpV9XATlP0KmYPsLc+Q==
+tsutils@^2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   dependencies:
     tslib "^1.8.1"
 
-typescript@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+tsutils@^3.0.0, tsutils@^3.5.0:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
-ua-parser-js@^0.7.9:
-  version "0.7.14"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -2493,14 +2447,14 @@ unicode-property-aliases-ecmascript@^1.0.4:
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
 
 union-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
-  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
+  integrity sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
   dependencies:
     arr-union "^3.1.0"
     get-value "^2.0.6"
     is-extendable "^0.1.1"
-    set-value "^0.4.3"
+    set-value "^2.0.1"
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -2511,9 +2465,9 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 upath@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
-  integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 urix@^0.1.0:
   version "0.1.0"
@@ -2530,10 +2484,6 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
 wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
@@ -2544,8 +2494,9 @@ wide-align@^1.1.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 yallist@^3.0.0, yallist@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
-  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
## Motivation

We can ensure that the props and state variables that are modified existing using Typescript typings. In the past, I'd done some manual things like:

```tsx
render() {
  const inputValue: keyof State = 'inputValue';
  return <input onChange={update(this, inputValue)} />;
}
```

I realized it's possible to remove all of these by just adding typings to `react-updaters`.

## Fix

1. Added a new type: `TypeSafeKey<T>` that allows for both a single type-safe string key or an array including them
2. Used either this or `keyof` for functions dealing with both props and state to ensure type-safety

For props:
```typescript
export function setProp<PropT>(
  elem: React.Component<any>,
  propFunc: keyof PropT,
  propIndex: keyof PropT,
  indexInProp: Keys | null | undefined,
  preventDefault?: boolean,
) {
```

For state:
```typescript
export function update<PropT, StateT>(
  elem: React.Component<PropT, StateT>,
  stateIndex: TypeSafeKeys<StateT>,
  preventDefault?: boolean,
) {
```

3. Made all functions not return `any`, by casting the return values retrieved from the cache. Instead, most change handlers now return callbacks of form `(e?: any) => any` or `(...args: any[]) => any`
4. Improved some internal typings

### One thing that doesn't work super well

The typings don't work well when the type of `Prop` or `State` is a union type. In those cases, a workaround is needed.

```tsx
import * as React from 'react';
import { callProp } from 'react-updaters';

interface BaseProps {
  onCommonClick: (myValue: string) => unknown;
}

type Props = BaseProps & ({ myFirstProp: boolean } | { mySecondProp: boolean });

export default class Example extends React.PureComponent<Props> {
  render() {
    return (
      <button
        type="button"
        // An error is on the next line
        // Property 'myFirstProp' is missing in type 'Readonly<BaseProps & { mySecondProp: boolean; }> & Readonly<{ children?: ReactNode; }>' but required in type 'Readonly<BaseProps & { myFirstProp: boolean; }>'.ts(2345)
        onClick={callProp(this, 'onCommonClick', ['myStr'])}
      />
    );
  }
}
```

An explicit cast of `this` to `this as React.PureComponent<BaseProps>` will do the trick

## Testing

I tested by adding this repository locally to the https://wanderlog.com codebase and ensuring that the typing breakages were the client's fault, rather than the fault of this library